### PR TITLE
Bump URLs for Mono & Xamarin

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,8 +23,8 @@ jobs:
         export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
         export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
         dotnet tool install --global boots
-        boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.189.macos10.xamarin.universal.pkg
-        boots https://aka.ms/xamarin-android-commercial-d16-3-macos
+        boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
+        boots https://aka.ms/xamarin-android-commercial-d16-4-macos
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage
 
   windows:
@@ -37,5 +37,5 @@ jobs:
      run: |
        $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE='true'
        dotnet tool install --global boots
-       boots https://aka.ms/xamarin-android-commercial-d16-3-windows
+       boots https://aka.ms/xamarin-android-commercial-d16-4-windows
        msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ steps:
 - task: Boots@1
   displayName: Install Xamarin.Android
   inputs:
-    uri: https://aka.ms/xamarin-android-commercial-d16-3-windows
+    uri: https://aka.ms/xamarin-android-commercial-d16-4-windows
 ```
 
 You can install the [Boots Extension from the VS Marketplace](https://marketplace.visualstudio.com/items?itemName=pjcollins.azp-utilities-boots).
@@ -48,7 +48,7 @@ variables:
 steps:
 - script: |
     dotnet tool install --global boots
-    boots https://aka.ms/xamarin-android-commercial-d16-3-windows
+    boots https://aka.ms/xamarin-android-commercial-d16-4-windows
 ```
 `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is optional, but will speed up the first `dotnet` command.
 
@@ -56,19 +56,19 @@ steps:
 
 Install Mono, Xamarin.Android, and Xamarin.iOS on Mac OSX:
 
-    boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.189.macos10.xamarin.universal.pkg
-    boots https://aka.ms/xamarin-android-commercial-d16-3-macos
-    boots https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/d532e90de664caf46baea6226d742b9f68b3173a/44/package/xamarin.ios-13.2.0.46.pkg
+    boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
+    boots https://aka.ms/xamarin-android-commercial-d16-4-macos
+    boots https://download.visualstudio.microsoft.com/download/pr/5a678460-107f-4fcf-8764-80419bc874a0/3f78c6826132f6f8569524690322adba/xamarin.ios-13.8.1.17.pkg
 
 Install Xamarin.Android on Windows:
 
-    boots https://aka.ms/xamarin-android-commercial-d16-3-windows
+    boots https://aka.ms/xamarin-android-commercial-d16-4-windows
 
 I got each URL from:
 
 * [Mono Downloads](https://www.mono-project.com/download/stable/#download-mac)
 * [Xamarin.Android README](https://github.com/xamarin/xamarin-android)
-* [Xamarin.iOS Github Status](https://github.com/xamarin/xamarin-macios/commits/d16-3)
+* [Xamarin.iOS Github Status](https://github.com/xamarin/xamarin-macios/commits/d16-4)
 
 To _upgrade_ .NET Core on Mac OSX, assuming you have some version of .NET Core to start with:
 
@@ -101,7 +101,7 @@ Task("Boots")
     .Does(async () =>
     {
         var platform = IsRunningOnWindows() ? "windows" : "macos";
-        await Boots ($"https://aka.ms/xamarin-android-commercial-d16-3-{platform}");
+        await Boots ($"https://aka.ms/xamarin-android-commercial-d16-4-{platform}");
     });
 ```
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,10 @@ variables:
   BootsVersion: 1.0.0
   BootsSuffix: ''
   PackageVersion: $(BootsVersion).$(Build.BuildNumber)$(BootsSuffix)
-  Mono.Pkg: https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.189.macos10.xamarin.universal.pkg
-  XA.Vsix: https://download.visualstudio.microsoft.com/download/pr/68e5a599-5d9b-4d59-b41a-8348d23faa73/abd0a8f9a6b6253facfaaa97e5e138509b004263134d310cc6d49c2f1ac734b9/Xamarin.Android.Sdk-10.0.0.40.vsix
-  XA.Pkg: https://download.visualstudio.microsoft.com/download/pr/edd7782e-dc4f-4be5-9b55-8a51eeb7a718/ed8c238ec095b5d1051e2539cea38113/xamarin.android-10.0.0.40.pkg
-  XA.Version: 10.0.0-40
+  Mono.Pkg: https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
+  XA.Vsix: https://download.visualstudio.microsoft.com/download/pr/c5d8e76d-8871-4b15-8391-b0569595c6bd/26dd9383f383cd737cddbfe4ed919877cf62ea42ff31e8293fd8a217e1008157/Xamarin.Android.Sdk-10.1.0.29.vsix
+  XA.Pkg: https://download.visualstudio.microsoft.com/download/pr/6dee3850-6d48-45c9-b25a-80c6abd3254e/04899faf2dd793d0bf3cfbd806a48560/xamarin.android-10.1.0.29.pkg
+  XA.Version: 10.1.0-29
   ShippedBoots: 1.0.0.291
   DotNetCoreVersion: 2.2.402
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/samples/HelloForms.Android/HelloForms.Android.csproj
+++ b/samples/HelloForms.Android/HelloForms.Android.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -56,7 +56,7 @@
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.0.0-preview02" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0-preview02" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.0.0-preview02" />
-    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.0-preview03" />
+    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.0-preview05" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.0.0-preview02" />
     <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />
   </ItemGroup>
@@ -89,11 +89,11 @@
     <AndroidResource Include="Resources\mipmap-xxxhdpi\launcher_foreground.png" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Resources\drawable\" />
     <Folder Include="Resources\drawable-hdpi\" />
     <Folder Include="Resources\drawable-xhdpi\" />
     <Folder Include="Resources\drawable-xxhdpi\" />
     <Folder Include="Resources\drawable-xxxhdpi\" />
+    <Folder Include="Resources\drawable\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\HelloForms\HelloForms.csproj">
@@ -103,9 +103,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Target Name="BeforeBuild">
-    <Message
-        Text="XamarinAndroidVersion: $(XamarinAndroidVersion)"
-        Importance="High"
-    />
+    <Message Text="XamarinAndroidVersion: $(XamarinAndroidVersion)" Importance="High" />
   </Target>
 </Project>

--- a/samples/HelloForms.Android/HelloForms.Android.csproj
+++ b/samples/HelloForms.Android/HelloForms.Android.csproj
@@ -52,13 +52,13 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.0.0.425677" />
+    <PackageReference Include="Xamarin.Forms" Version="4.3.0.947036" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.0.0-preview02" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0-preview02" />
     <PackageReference Include="Xamarin.AndroidX.MediaRouter" Version="1.0.0-preview02" />
     <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.0-preview05" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.0.0-preview02" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />

--- a/samples/HelloForms.Android/appcenter-pre-build.sh
+++ b/samples/HelloForms.Android/appcenter-pre-build.sh
@@ -4,5 +4,5 @@
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
 
 dotnet tool install --global boots
-boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.189.macos10.xamarin.universal.pkg
-boots https://aka.ms/xamarin-android-commercial-d16-3-macos
+boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
+boots https://aka.ms/xamarin-android-commercial-d16-4-macos

--- a/samples/HelloForms.iOS/HelloForms.iOS.csproj
+++ b/samples/HelloForms.iOS/HelloForms.iOS.csproj
@@ -124,8 +124,8 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.0.0.425677" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />
+    <PackageReference Include="Xamarin.Forms" Version="4.3.0.947036" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/samples/HelloForms/HelloForms.csproj
+++ b/samples/HelloForms/HelloForms.csproj
@@ -1,15 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DebugType>pdbonly</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Xamarin.Forms" Version="4.0.0.425677" />
     <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />

--- a/samples/HelloForms/HelloForms.csproj
+++ b/samples/HelloForms/HelloForms.csproj
@@ -4,7 +4,7 @@
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.0.0.425677" />
-    <PackageReference Include="Xamarin.Essentials" Version="1.1.0" />
+    <PackageReference Include="Xamarin.Forms" Version="4.3.0.947036" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We have 16.4 Preview URLs now.

Bump Mono to a slightly newer version as well.