### PR TITLE
Build with .NET Core 3.0

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -21,11 +21,12 @@ jobs:
         # Workaround, see: https://github.com/dotnet/cli/issues/9114#issuecomment-494226139
         export PATH="$PATH:~/.dotnet/tools"
         export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
-        export DOTNET_CLI_TELEMETRY_OPTOUT=true
         dotnet tool install --global boots
         boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
         boots https://aka.ms/xamarin-android-commercial-d16-4-macos
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
 
   windows:
    runs-on: windows-latest
@@ -33,8 +34,10 @@ jobs:
    - uses: actions/checkout@v1
    - uses: warrenbuckley/Setup-MSBuild@v1
    - name: build
-     shell: pwsh
-     run: |
-       dotnet tool install --global boots
-       boots https://aka.ms/xamarin-android-commercial-d16-4-windows
-       msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage
+      shell: pwsh
+      run: |
+        dotnet tool install --global boots
+        boots https://aka.ms/xamarin-android-commercial-d16-4-windows
+        msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage
+      env:
+        DOTNET_CLI_TELEMETRY_OPTOUT: 'true'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,6 +18,7 @@ jobs:
       run: |
         wget https://dot.net/v1/dotnet-install.sh
         sh dotnet-install.sh -Version 3.0.100
+        export PATH="$PATH:~/.dotnet/tools"
     - name: build
       shell: bash
       run: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,10 +15,12 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
     steps:
     - uses: actions/checkout@v1
-    - name: install .NET Core
+    - name: build
       shell: bash
       run: |
         wget https://dot.net/v1/dotnet-install.sh
+        # NOTE: temporarily installing *both* 2.2 and 3.0
+        sh dotnet-install.sh -Version 2.2.402
         sh dotnet-install.sh -Version 3.0.100
         # Workaround, see: https://github.com/dotnet/cli/issues/9114#issuecomment-494226139
         export PATH="$PATH:~/.dotnet/tools"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: macOS-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
     steps:
     - uses: actions/checkout@v1
     - name: build
@@ -34,6 +35,7 @@ jobs:
     runs-on: windows-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
     steps:
     - uses: actions/checkout@v1
     - uses: warrenbuckley/Setup-MSBuild@v1

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,15 +13,14 @@ jobs:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
-    - name: build
+    - name: install .NET Core
       shell: bash
       run: |
         wget https://dot.net/v1/dotnet-install.sh
-        sh dotnet-install.sh -Version 2.2.402
-        # Workaround, see: https://github.com/dotnet/cli/issues/9114#issuecomment-494226139
-        export PATH="$PATH:~/.dotnet/tools"
-        export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
-        export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+        sh dotnet-install.sh -Version 3.0.100
+    - name: build
+      shell: bash
+      run: |
         dotnet tool install --global boots
         boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
         boots https://aka.ms/xamarin-android-commercial-d16-4-macos
@@ -35,7 +34,6 @@ jobs:
    - name: build
      shell: pwsh
      run: |
-       $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE='true'
        dotnet tool install --global boots
        boots https://aka.ms/xamarin-android-commercial-d16-4-windows
        msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,11 +18,11 @@ jobs:
       run: |
         wget https://dot.net/v1/dotnet-install.sh
         sh dotnet-install.sh -Version 3.0.100
-        export PATH="$PATH:~/.dotnet/tools"
     - name: build
       shell: bash
       run: |
         dotnet tool install --global boots
+        export PATH="$PATH:~/.dotnet/tools"
         boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
         boots https://aka.ms/xamarin-android-commercial-d16-4-macos
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   macOS:
     runs-on: macOS-latest
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
     steps:
     - uses: actions/checkout@v1
     - name: install .NET Core
@@ -25,19 +27,17 @@ jobs:
         boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
         boots https://aka.ms/xamarin-android-commercial-d16-4-macos
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage
-      env:
-        DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
 
   windows:
-   runs-on: windows-latest
-   steps:
-   - uses: actions/checkout@v1
-   - uses: warrenbuckley/Setup-MSBuild@v1
-   - name: build
+    runs-on: windows-latest
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
+    steps:
+    - uses: actions/checkout@v1
+    - uses: warrenbuckley/Setup-MSBuild@v1
+    - name: build
       shell: pwsh
       run: |
         dotnet tool install --global boots
         boots https://aka.ms/xamarin-android-commercial-d16-4-windows
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage
-      env:
-        DOTNET_CLI_TELEMETRY_OPTOUT: 'true'

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -18,11 +18,11 @@ jobs:
       run: |
         wget https://dot.net/v1/dotnet-install.sh
         sh dotnet-install.sh -Version 3.0.100
-    - name: build
-      shell: bash
-      run: |
-        dotnet tool install --global boots
+        # Workaround, see: https://github.com/dotnet/cli/issues/9114#issuecomment-494226139
         export PATH="$PATH:~/.dotnet/tools"
+        export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
+        export DOTNET_CLI_TELEMETRY_OPTOUT=true
+        dotnet tool install --global boots
         boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
         boots https://aka.ms/xamarin-android-commercial-d16-4-macos
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage

--- a/Boots.Tests/Boots.Tests.csproj
+++ b/Boots.Tests/Boots.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Boots/Boots.csproj
+++ b/Boots/Boots.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>boots</ToolCommandName>
     <PackageOutputPath>..\bin</PackageOutputPath>

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ steps:
     dotnet tool install --global boots
     boots https://aka.ms/xamarin-android-commercial-d16-4-windows
 ```
-`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is optional, but will speed up the first `dotnet` command.
+`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is optional, but will speed up the first `dotnet` command. It is no longer needed on .NET Core 3.0, however.
 
 ## Some Examples
 
@@ -74,12 +74,6 @@ I got each URL from:
 * [Mono Downloads](https://www.mono-project.com/download/stable/#download-mac)
 * [Xamarin.Android README](https://github.com/xamarin/xamarin-android)
 * [Xamarin.iOS Github Status](https://github.com/xamarin/xamarin-macios/commits/d16-4)
-
-To _upgrade_ .NET Core on Mac OSX, assuming you have some version of .NET Core to start with:
-
-    boots https://download.visualstudio.microsoft.com/download/pr/1440e4a9-4e5f-4148-b8d2-8a2b3da4e622/d0c5cb2712e51c188200ea420d771c2f/dotnet-sdk-2.2.301-osx-x64.pkg
-
-Url from: [.NET Core Downloads](https://dotnet.microsoft.com/download/dotnet-core/2.2). _NOTE: I used the Network tab in Chrome to find the final URL_.
 
 ### App Center
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,8 +16,7 @@ variables:
   XA.Pkg: https://download.visualstudio.microsoft.com/download/pr/6dee3850-6d48-45c9-b25a-80c6abd3254e/04899faf2dd793d0bf3cfbd806a48560/xamarin.android-10.1.0.29.pkg
   XA.Version: 10.1.0-29
   ShippedBoots: 1.0.0.291
-  DotNetCoreVersion: 2.2.402
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DotNetCoreVersion: 3.0.100
 
 jobs:
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,6 +17,8 @@ variables:
   XA.Version: 10.1.0-29
   ShippedBoots: 1.0.0.291
   DotNetCoreVersion: 3.0.100
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
 
@@ -41,6 +43,12 @@ jobs:
     name: Hosted macOS
     demands: msbuild
   steps:
+
+  # NOTE: temporarily installing *both* 2.2 and 3.0
+  - task: UseDotNet@2
+    displayName: install .NET Core
+    inputs:
+      version: 2.2.402
 
   - task: UseDotNet@2
     displayName: install .NET Core

--- a/scripts/build-and-test.yaml
+++ b/scripts/build-and-test.yaml
@@ -10,7 +10,7 @@ steps:
     msbuildArguments: '/restore /t:Build,Pack /bl:$(System.DefaultWorkingDirectory)/bin/boots.binlog'
 
 - script: |
-    dotnet vstest Boots.Tests/bin/$(Configuration)/netcoreapp2.0/Boots.Tests.dll --logger:trx
+    dotnet vstest Boots.Tests/bin/$(Configuration)/netcoreapp3.0/Boots.Tests.dll --logger:trx
   displayName: Run tests
 
 - task: PublishTestResults@2


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/boots/issues/19

`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is no longer needed.