### PR TITLE
Test boots 1.0.1

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -13,19 +13,14 @@ jobs:
     runs-on: macOS-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
     steps:
     - uses: actions/checkout@v1
     - name: build
       shell: bash
       run: |
         wget https://dot.net/v1/dotnet-install.sh
-        # NOTE: temporarily installing *both* 2.2 and 3.0
-        sh dotnet-install.sh -Version 2.2.402
         sh dotnet-install.sh -Version 3.0.100
-        # Workaround, see: https://github.com/dotnet/cli/issues/9114#issuecomment-494226139
         export PATH="$PATH:~/.dotnet/tools"
-        export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
         dotnet tool install --global boots
         boots https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
         boots https://aka.ms/xamarin-android-commercial-d16-4-macos
@@ -35,7 +30,6 @@ jobs:
     runs-on: windows-latest
     env:
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
-      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 'true'
     steps:
     - uses: actions/checkout@v1
     - uses: warrenbuckley/Setup-MSBuild@v1

--- a/README.md
+++ b/README.md
@@ -49,13 +49,16 @@ If you don't want to use the extension, alternatively you can:
 
 ```yaml
 variables:
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
 steps:
 - script: |
     dotnet tool install --global boots
     boots https://aka.ms/xamarin-android-commercial-d16-4-windows
 ```
-`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is optional, but will speed up the first `dotnet` command. It is no longer needed on .NET Core 3.0, however.
+
+`DOTNET_CLI_TELEMETRY_OPTOUT` is optional.
+
+`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is also a good idea if you are running on a .NET Core older than 3.0.
 
 ## Some Examples
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ variables:
   XA.Vsix: https://download.visualstudio.microsoft.com/download/pr/c5d8e76d-8871-4b15-8391-b0569595c6bd/26dd9383f383cd737cddbfe4ed919877cf62ea42ff31e8293fd8a217e1008157/Xamarin.Android.Sdk-10.1.0.29.vsix
   XA.Pkg: https://download.visualstudio.microsoft.com/download/pr/6dee3850-6d48-45c9-b25a-80c6abd3254e/04899faf2dd793d0bf3cfbd806a48560/xamarin.android-10.1.0.29.pkg
   XA.Version: 10.1.0-29
-  ShippedBoots: 1.0.0.291
+  ShippedBoots: 1.0.1.386
   DotNetCoreVersion: 3.0.100
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -44,12 +44,6 @@ jobs:
     demands: msbuild
   steps:
 
-  # NOTE: temporarily installing *both* 2.2 and 3.0
-  - task: UseDotNet@2
-    displayName: install .NET Core
-    inputs:
-      version: 2.2.402
-
   - task: UseDotNet@2
     displayName: install .NET Core
     inputs:
@@ -59,6 +53,7 @@ jobs:
     displayName: install Mono
     inputs:
       uri: $(Mono.Pkg)
+      version: $(ShippedBoots)
 
   - template: scripts/build-and-test.yaml
     parameters:


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/boots/issues/19

We should be able to drop all the .NET Core 2.2 installs now?