### PR TITLE
New auto-resolving url feature

### DIFF
--- a/Boots.Core/Boots.Core.csproj
+++ b/Boots.Core/Boots.Core.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="4.7.0" />
+  </ItemGroup>
+
 </Project>

--- a/Boots.Core/Bootstrapper.cs
+++ b/Boots.Core/Bootstrapper.cs
@@ -10,16 +10,29 @@ namespace Boots.Core
 {
 	public class Bootstrapper
 	{
+		public ReleaseChannel? Channel { get; set; }
+
+		public Product? Product { get; set; }
+
 		public string Url { get; set; }
 
 		public TextWriter Logger { get; set; } = Console.Out;
 
 		public async Task Install (CancellationToken token = new CancellationToken ())
 		{
-			if (string.IsNullOrEmpty (Url))
-				throw new ArgumentNullException (nameof (Uri));
+			if (string.IsNullOrEmpty (Url)) {
+				if (Channel == null)
+					throw new ArgumentNullException (nameof (Channel));
+				if (Product == null)
+					throw new ArgumentNullException (nameof (Product));
 
-			Installer installer = null;
+				var resolver = Helpers.IsMac ?
+					(UrlResolver) new MacUrlResolver () :
+					(UrlResolver) new WindowsUrlResolver ();
+				Url = await resolver.Resolve (Channel.Value, Product.Value);
+			}
+
+			Installer installer;
 			if (Helpers.IsWindows) {
 				installer = new VsixInstaller (this);
 			} else {

--- a/Boots.Core/Bootstrapper.cs
+++ b/Boots.Core/Bootstrapper.cs
@@ -26,6 +26,8 @@ namespace Boots.Core
 				if (Product == null)
 					throw new ArgumentNullException (nameof (Product));
 
+				Logger.WriteLine ("* Automatic URL resolving is a new feature. File issues at: https://github.com/jonathanpeppers/boots/issues");
+
 				var resolver = Helpers.IsMac ?
 					(UrlResolver) new MacUrlResolver (this) :
 					(UrlResolver) new WindowsUrlResolver (this);

--- a/Boots.Core/Bootstrapper.cs
+++ b/Boots.Core/Bootstrapper.cs
@@ -27,8 +27,8 @@ namespace Boots.Core
 					throw new ArgumentNullException (nameof (Product));
 
 				var resolver = Helpers.IsMac ?
-					(UrlResolver) new MacUrlResolver () :
-					(UrlResolver) new WindowsUrlResolver ();
+					(UrlResolver) new MacUrlResolver (this) :
+					(UrlResolver) new WindowsUrlResolver (this);
 				Url = await resolver.Resolve (Channel.Value, Product.Value);
 			}
 

--- a/Boots.Core/Downloader.cs
+++ b/Boots.Core/Downloader.cs
@@ -28,10 +28,12 @@ namespace Boots.Core
 				var request = new HttpRequestMessage (HttpMethod.Get, uri);
 				var response = await client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead, token);
 				response.EnsureSuccessStatusCode ();
-				using (var httpStream = await response.Content.ReadAsStreamAsync ())
-				using (var fileStream = File.Create (TempFile)) {
-					boots.Logger.WriteLine ($"Writing to {TempFile}");
-					await httpStream.CopyToAsync (fileStream, 8 * 1024, token);
+				using (var httpStream = await response.Content.ReadAsStreamAsync ()) {
+					token.ThrowIfCancellationRequested ();
+					using (var fileStream = File.Create (TempFile)) {
+						boots.Logger.WriteLine ($"Writing to {TempFile}");
+						await httpStream.CopyToAsync (fileStream, 8 * 1024, token);
+					}
 				}
 			}
 		}

--- a/Boots.Core/MacUrlResolver.cs
+++ b/Boots.Core/MacUrlResolver.cs
@@ -48,7 +48,6 @@ namespace Boots.Core
 
 				// Just let this throw if it is an invalid Uri
 				new Uri (url);
-
 				return url;
 			}
 		}

--- a/Boots.Core/MacUrlResolver.cs
+++ b/Boots.Core/MacUrlResolver.cs
@@ -6,7 +6,7 @@ using System.Xml;
 
 namespace Boots.Core
 {
-	public class MacUrlResolver : UrlResolver
+	class MacUrlResolver : UrlResolver
 	{
 		const string Url = "https://software.xamarin.com/Service/Updates?v=2&pv964ebddd-1ffe-47e7-8128-5ce17ffffb05=0&pv4569c276-1397-4adb-9485-82a7696df22e=0&pvd1ec039f-f3db-468b-a508-896d7c382999=0&pv0ab364ff-c0e9-43a8-8747-3afb02dc7731=0&level=";
 		static readonly Dictionary<Product, string> ProductIds = new Dictionary<Product, string> {

--- a/Boots.Core/MacUrlResolver.cs
+++ b/Boots.Core/MacUrlResolver.cs
@@ -60,14 +60,14 @@ namespace Boots.Core
 				case ReleaseChannel.Preview:
 					return "Beta";
 				default:
-					throw new NotImplementedException ($"Unexpected value for {nameof (ReleaseChannel)}: {channel}");
+					throw new NotImplementedException ($"Unexpected value for release: {channel}");
 			}
 		}
 
 		string GetProductId (Product product)
 		{
 			if (!ProductIds.TryGetValue (product, out string id)) {
-				throw new NotImplementedException ($"Unexpected value for {nameof (Product)}: {product}");
+				throw new NotImplementedException ($"Unexpected value for product: {product}");
 			}
 			return id;
 		}

--- a/Boots.Core/MacUrlResolver.cs
+++ b/Boots.Core/MacUrlResolver.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace Boots.Core
+{
+	public class MacUrlResolver : UrlResolver
+	{
+		const string Url = "https://software.xamarin.com/Service/Updates?v=2&pv964ebddd-1ffe-47e7-8128-5ce17ffffb05=0&pv4569c276-1397-4adb-9485-82a7696df22e=0&pvd1ec039f-f3db-468b-a508-896d7c382999=0&pv0ab364ff-c0e9-43a8-8747-3afb02dc7731=0&level=";
+		static readonly Dictionary<Product, string> ProductIds = new Dictionary<Product, string> {
+			{ Product.Mono,           "964ebddd-1ffe-47e7-8128-5ce17ffffb05" },
+			{ Product.XamarinAndroid, "d1ec039f-f3db-468b-a508-896d7c382999" },
+			{ Product.XamariniOS,     "4569c276-1397-4adb-9485-82a7696df22e" },
+		};
+
+		HttpClient httpClient = new HttpClient ();
+
+		public async override Task<string> Resolve (ReleaseChannel channel, Product product)
+		{
+			string level = GetLevel (channel);
+			string productId = GetProductId (product);
+
+			var response = await httpClient.GetAsync (Url + level);
+			response.EnsureSuccessStatusCode ();
+
+			var document = new XmlDocument ();
+			using (var stream = await response.Content.ReadAsStreamAsync ()) {
+				document.Load (stream);
+
+				var node = document.SelectSingleNode ($"/UpdateInfo/Application[@id='{productId}']/Update/@url");
+				if (node == null) {
+					throw new XmlException ($"Did not find {channel}, at channel {product}");
+				}
+
+				string url = node.InnerText;
+				if (string.IsNullOrEmpty (url)) {
+					throw new XmlException ($"Did not find {channel}, at channel {product}");
+				}
+				return url;
+			}
+		}
+
+		string GetLevel (ReleaseChannel channel)
+		{
+			switch (channel) {
+				case ReleaseChannel.Stable:
+					return "Stable";
+				case ReleaseChannel.Preview:
+					return "Beta";
+				default:
+					throw new NotImplementedException ($"Unexpected value for {nameof (ReleaseChannel)}: {channel}");
+			}
+		}
+
+		string GetProductId (Product product)
+		{
+			if (!ProductIds.TryGetValue (product, out string id)) {
+				throw new NotImplementedException ($"Unexpected value for {nameof (Product)}: {product}");
+			}
+			return id;
+		}
+	}
+}

--- a/Boots.Core/MacUrlResolver.cs
+++ b/Boots.Core/MacUrlResolver.cs
@@ -13,6 +13,7 @@ namespace Boots.Core
 			{ Product.Mono,           "964ebddd-1ffe-47e7-8128-5ce17ffffb05" },
 			{ Product.XamarinAndroid, "d1ec039f-f3db-468b-a508-896d7c382999" },
 			{ Product.XamariniOS,     "4569c276-1397-4adb-9485-82a7696df22e" },
+			{ Product.XamarinMac,     "0ab364ff-c0e9-43a8-8747-3afb02dc7731" },
 		};
 
 		HttpClient httpClient = new HttpClient ();
@@ -31,13 +32,17 @@ namespace Boots.Core
 
 				var node = document.SelectSingleNode ($"/UpdateInfo/Application[@id='{productId}']/Update/@url");
 				if (node == null) {
-					throw new XmlException ($"Did not find {channel}, at channel {product}");
+					throw new XmlException ($"Did not find {product}, at channel {channel}");
 				}
 
 				string url = node.InnerText;
 				if (string.IsNullOrEmpty (url)) {
-					throw new XmlException ($"Did not find {channel}, at channel {product}");
+					throw new XmlException ($"Did not find {product}, at channel {channel}");
 				}
+
+				// Just let this throw if it is an invalid Uri
+				new Uri (url);
+
 				return url;
 			}
 		}

--- a/Boots.Core/Product.cs
+++ b/Boots.Core/Product.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Boots.Core
+{
+	public enum Product
+	{
+		Mono,
+		XamarinAndroid,
+		XamariniOS,
+	}
+}

--- a/Boots.Core/Product.cs
+++ b/Boots.Core/Product.cs
@@ -1,12 +1,7 @@
-using System;
-
-namespace Boots.Core
+public enum Product
 {
-	public enum Product
-	{
-		Mono,
-		XamarinAndroid,
-		XamariniOS,
-		XamarinMac,
-	}
+	Mono,
+	XamarinAndroid,
+	XamariniOS,
+	XamarinMac,
 }

--- a/Boots.Core/Product.cs
+++ b/Boots.Core/Product.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Boots.Core
 {
@@ -9,5 +7,6 @@ namespace Boots.Core
 		Mono,
 		XamarinAndroid,
 		XamariniOS,
+		XamarinMac,
 	}
 }

--- a/Boots.Core/ReleaseChannel.cs
+++ b/Boots.Core/ReleaseChannel.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Boots.Core
+{
+	public enum ReleaseChannel
+	{
+		Stable,
+		Preview,
+	}
+}

--- a/Boots.Core/ReleaseChannel.cs
+++ b/Boots.Core/ReleaseChannel.cs
@@ -1,10 +1,5 @@
-using System;
-
-namespace Boots.Core
+public enum ReleaseChannel
 {
-	public enum ReleaseChannel
-	{
-		Stable,
-		Preview,
-	}
+	Stable,
+	Preview,
 }

--- a/Boots.Core/UrlResolver.cs
+++ b/Boots.Core/UrlResolver.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Boots.Core
+{
+	public abstract class UrlResolver
+	{
+		public abstract Task<string> Resolve (ReleaseChannel channel, Product product);
+	}
+}

--- a/Boots.Core/UrlResolver.cs
+++ b/Boots.Core/UrlResolver.cs
@@ -1,9 +1,17 @@
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Boots.Core
 {
 	abstract class UrlResolver
 	{
-		public abstract Task<string> Resolve (ReleaseChannel channel, Product product);
+		protected readonly Bootstrapper Boots;
+
+		public UrlResolver (Bootstrapper boots)
+		{
+			Boots = boots;
+		}
+
+		public abstract Task<string> Resolve (ReleaseChannel channel, Product product, CancellationToken token = new CancellationToken ());
 	}
 }

--- a/Boots.Core/UrlResolver.cs
+++ b/Boots.Core/UrlResolver.cs
@@ -1,9 +1,8 @@
-using System;
 using System.Threading.Tasks;
 
 namespace Boots.Core
 {
-	public abstract class UrlResolver
+	abstract class UrlResolver
 	{
 		public abstract Task<string> Resolve (ReleaseChannel channel, Product product);
 	}

--- a/Boots.Core/WindowsUrlResolver.cs
+++ b/Boots.Core/WindowsUrlResolver.cs
@@ -1,11 +1,17 @@
 using System;
+using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Boots.Core
 {
 	class WindowsUrlResolver : UrlResolver
 	{
-		public override Task<string> Resolve (ReleaseChannel channel, Product product)
+		readonly HttpClient httpClient = new HttpClient ();
+
+		public WindowsUrlResolver (Bootstrapper boots) : base (boots) { }
+
+		public override Task<string> Resolve (ReleaseChannel channel, Product product, CancellationToken token = new CancellationToken ())
 		{
 			throw new NotImplementedException ();
 		}

--- a/Boots.Core/WindowsUrlResolver.cs
+++ b/Boots.Core/WindowsUrlResolver.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Boots.Core
+{
+	class WindowsUrlResolver : UrlResolver
+	{
+		public override Task<string> Resolve (ReleaseChannel channel, Product product)
+		{
+			throw new NotImplementedException ();
+		}
+	}
+}

--- a/Boots.Core/WindowsUrlResolver.cs
+++ b/Boots.Core/WindowsUrlResolver.cs
@@ -79,7 +79,7 @@ namespace Boots.Core
 				case ReleaseChannel.Preview:
 					return "Microsoft.VisualStudio.Manifests.VisualStudioPreview";
 				default:
-					throw new NotImplementedException ($"Unexpected value for {nameof (ReleaseChannel)}: {channel}"); ;
+					throw new NotImplementedException ($"Unexpected value for release: {channel}"); ;
 			}
 		}
 
@@ -91,9 +91,9 @@ namespace Boots.Core
 				case Product.Mono:
 				case Product.XamariniOS:
 				case Product.XamarinMac:
-					throw new NotImplementedException ($"Value for {nameof (Product)} not implemented on Windows: {product}");
+					throw new NotImplementedException ($"Value for product not implemented on Windows: {product}");
 				default:
-					throw new NotImplementedException ($"Unexpected value for {nameof (Product)}: {product}");
+					throw new NotImplementedException ($"Unexpected value for product: {product}");
 			}
 		}
 

--- a/Boots.Core/WindowsUrlResolver.cs
+++ b/Boots.Core/WindowsUrlResolver.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -7,13 +9,114 @@ namespace Boots.Core
 {
 	class WindowsUrlResolver : UrlResolver
 	{
+		const string ReleaseUrl = "https://aka.ms/vs/16/release/channel";
+		const string PreviewUrl = "https://aka.ms/vs/16/pre/channel";
+
 		readonly HttpClient httpClient = new HttpClient ();
 
 		public WindowsUrlResolver (Bootstrapper boots) : base (boots) { }
 
-		public override Task<string> Resolve (ReleaseChannel channel, Product product, CancellationToken token = new CancellationToken ())
+		public async override Task<string> Resolve (ReleaseChannel channel, Product product, CancellationToken token = new CancellationToken ())
 		{
-			throw new NotImplementedException ();
+			Uri uri = GetUri (channel);
+			string channelId = GetChannelId (channel);
+			string productId = GetProductId (product);
+
+			Boots.Logger.WriteLine ($"Querying {uri}");
+			var response = await httpClient.GetAsync (uri, token);
+			response.EnsureSuccessStatusCode ();
+
+			string payloadManifestUrl;
+			using (var stream = await response.Content.ReadAsStreamAsync ()) {
+				token.ThrowIfCancellationRequested ();
+				var manifest = await JsonSerializer.DeserializeAsync<VSManifest> (stream, cancellationToken: token);
+				var channelItem = manifest.channelItems?.FirstOrDefault (c => c.id == channelId);
+				if (channelItem == null) {
+					throw new InvalidOperationException ($"Did not find '{channelId}' at: {uri}");
+				}
+				payloadManifestUrl = channelItem.payloads?.Select (p => p.url)?.FirstOrDefault ();
+				if (string.IsNullOrEmpty (payloadManifestUrl)) {
+					throw new InvalidOperationException ($"Did not find manifest url for '{channelId}' at: {uri}");
+				}
+			}
+
+			uri = new Uri (payloadManifestUrl);
+			Boots.Logger.WriteLine ($"Querying {uri}");
+			response = await httpClient.GetAsync (uri, token);
+			response.EnsureSuccessStatusCode ();
+
+			using (var stream = await response.Content.ReadAsStreamAsync ()) {
+				token.ThrowIfCancellationRequested ();
+				var payload = await JsonSerializer.DeserializeAsync<VSPayloadManifest> (stream, cancellationToken: token);
+				var url = payload.packages?.FirstOrDefault (p => p.id == productId)?.payloads?.Select (p => p.url).FirstOrDefault ();
+				if (string.IsNullOrEmpty (url)) {
+					throw new InvalidOperationException ($"Did not find payload url for '{productId}' at: {uri}");
+				}
+
+				// Just let this throw if it is an invalid Uri
+				new Uri (url);
+				return url;
+			}
+		}
+
+		Uri GetUri (ReleaseChannel channel)
+		{
+			switch (channel) {
+				case ReleaseChannel.Stable:
+					return new Uri (ReleaseUrl);
+				case ReleaseChannel.Preview:
+					return new Uri (PreviewUrl);
+				default:
+					throw new NotImplementedException ($"Unexpected value for {nameof (ReleaseChannel)}: {channel}"); ;
+			}
+		}
+
+		string GetChannelId (ReleaseChannel channel)
+		{
+			switch (channel) {
+				case ReleaseChannel.Stable:
+					return "Microsoft.VisualStudio.Manifests.VisualStudio";
+				case ReleaseChannel.Preview:
+					return "Microsoft.VisualStudio.Manifests.VisualStudioPreview";
+				default:
+					throw new NotImplementedException ($"Unexpected value for {nameof (ReleaseChannel)}: {channel}"); ;
+			}
+		}
+
+		string GetProductId (Product product)
+		{
+			switch (product) {
+				case Product.XamarinAndroid:
+					return "Xamarin.Android.Sdk";
+				case Product.Mono:
+				case Product.XamariniOS:
+				case Product.XamarinMac:
+					throw new NotImplementedException ($"Value for {nameof (Product)} not implemented on Windows: {product}");
+				default:
+					throw new NotImplementedException ($"Unexpected value for {nameof (Product)}: {product}");
+			}
+		}
+
+		class VSManifest
+		{
+			public VSPackage [] channelItems { get; set; }
+		}
+
+		class VSPayload
+		{
+			public string url { get; set; }
+		}
+
+		class VSPayloadManifest
+		{
+			public VSPackage [] packages { get; set; }
+		}
+
+		class VSPackage
+		{
+			public string id { get; set; }
+
+			public VSPayload [] payloads { get; set; }
 		}
 	}
 }

--- a/Boots.Tests/UrlResolverTests.cs
+++ b/Boots.Tests/UrlResolverTests.cs
@@ -24,10 +24,26 @@ namespace Boots.Tests
 
 		public async Task Resolve (Type type, ReleaseChannel channel, Product product)
 		{
-			var resolver = (UrlResolver) Activator.CreateInstance (type);
+			var resolver = (UrlResolver) Activator.CreateInstance (type, new Bootstrapper ());
 			var url = await resolver.Resolve (channel, product);
 			var response = await client.GetAsync (url, HttpCompletionOption.ResponseHeadersRead);
 			response.EnsureSuccessStatusCode ();
+		}
+
+		[Theory]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Stable, Product.XamariniOS)]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Stable, Product.XamarinMac)]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Stable, Product.Mono)]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Preview, Product.XamariniOS)]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Preview, Product.XamarinMac)]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Preview, Product.Mono)]
+		[InlineData (typeof (WindowsUrlResolver), (ReleaseChannel) 9999, Product.Mono)]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Preview, (Product) 9999)]
+
+		public async Task NotImplemented (Type type, ReleaseChannel channel, Product product)
+		{
+			var resolver = (UrlResolver) Activator.CreateInstance (type, new Bootstrapper ());
+			await Assert.ThrowsAsync<NotImplementedException> (() => resolver.Resolve (channel, product));
 		}
 	}
 }

--- a/Boots.Tests/UrlResolverTests.cs
+++ b/Boots.Tests/UrlResolverTests.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Boots.Core;
+using Xunit;
+
+namespace Boots.Tests
+{
+	public class UrlResolverTests
+	{
+		HttpClient client = new HttpClient ();
+
+		[Theory]
+		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Stable, Product.XamarinAndroid)]
+		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Stable, Product.XamariniOS)]
+		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Stable, Product.Mono)]
+		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.XamarinAndroid)]
+		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.XamariniOS)]
+		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.Mono)]
+
+		public async Task Resolve (Type type, ReleaseChannel channel, Product product)
+		{
+			var resolver = (UrlResolver) Activator.CreateInstance (type);
+			var url = await resolver.Resolve (channel, product);
+			var response = await client.GetAsync (url, HttpCompletionOption.ResponseHeadersRead);
+			response.EnsureSuccessStatusCode ();
+		}
+	}
+}

--- a/Boots.Tests/UrlResolverTests.cs
+++ b/Boots.Tests/UrlResolverTests.cs
@@ -19,6 +19,8 @@ namespace Boots.Tests
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.XamariniOS)]
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.XamarinMac)]
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.Mono)]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Stable, Product.XamarinAndroid)]
+		[InlineData (typeof (WindowsUrlResolver), ReleaseChannel.Preview, Product.XamarinAndroid)]
 
 		public async Task Resolve (Type type, ReleaseChannel channel, Product product)
 		{

--- a/Boots.Tests/UrlResolverTests.cs
+++ b/Boots.Tests/UrlResolverTests.cs
@@ -13,9 +13,11 @@ namespace Boots.Tests
 		[Theory]
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Stable, Product.XamarinAndroid)]
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Stable, Product.XamariniOS)]
+		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Stable, Product.XamarinMac)]
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Stable, Product.Mono)]
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.XamarinAndroid)]
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.XamariniOS)]
+		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.XamarinMac)]
 		[InlineData (typeof (MacUrlResolver), ReleaseChannel.Preview, Product.Mono)]
 
 		public async Task Resolve (Type type, ReleaseChannel channel, Product product)

--- a/Boots/Boots.csproj
+++ b/Boots/Boots.csproj
@@ -11,6 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20071.2" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Boots.Core\Boots.Core.csproj" />
   </ItemGroup>
 

--- a/Boots/Program.cs
+++ b/Boots/Program.cs
@@ -1,4 +1,6 @@
 using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.Threading;
 using System.Threading.Tasks;
 using Boots.Core;
@@ -9,34 +11,70 @@ namespace Boots
 	{
 		static async Task Main (string [] args)
 		{
-			Version ();
-			if (args.Length == 0 || args [0] == "--help") {
-				Help ();
+			if (args.Length == 1 && IsUrl (args[0])) {
+				await Run (args [0]);
 				return;
 			}
 
+			const string options = "Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac and Mono.";
+			var rootCommand = new RootCommand
+			{
+				new Option(
+					"--url",
+					"A URL to a pkg or vsix file to install")
+				{
+					Argument = new Argument<string>()
+				},
+				new Option(
+					"--stable",
+					$"Install the latest *stable* version of a product from VS manifests. {options}")
+				{
+					Argument = new Argument<string>()
+				},
+				new Option(
+					"--preview",
+					$"Install the latest *preview* version of a product from VS manifests. {options}")
+				{
+					Argument = new Argument<string>()
+				},
+			};
+			rootCommand.Name = "boots";
+			rootCommand.Description = $"boots {Version}";
+			rootCommand.Handler = CommandHandler.Create <string, string, string> (Run);
+			await rootCommand.InvokeAsync (args);
+		}
+
+		static bool IsUrl (string value)
+		{
+			try {
+				new Uri (value);
+				return true;
+			} catch (UriFormatException) {
+				return false;
+			}
+		}
+
+		static async Task Run (string url, string stable = null, string preview = null)
+		{
 			var cts = new CancellationTokenSource ();
 			Console.CancelKeyPress += (sender, e) => cts.Cancel ();
 
 			var boots = new Bootstrapper {
-				Url = args [0],
+				Url = url,
 			};
+			SetChannelAndProduct (boots, preview, ReleaseChannel.Preview);
+			SetChannelAndProduct (boots, stable,  ReleaseChannel.Stable);
 			await boots.Install (cts.Token);
 		}
 
-		static void Version ()
+		static void SetChannelAndProduct (Bootstrapper boots, string product, ReleaseChannel channel)
 		{
-			var name = typeof (Program).Assembly.GetName ();
-			Console.WriteLine ($"boots {name.Version}");
+			if (!string.IsNullOrEmpty (product)) {
+				boots.Channel = channel;
+				boots.Product = Enum.Parse<Product> (product.Replace (".", ""));
+			}
 		}
 
-		static void Help ()
-		{
-			Console.WriteLine ();
-			Console.WriteLine ("usage:");
-			Console.WriteLine ("\tboots https://url/to/your/package");
-			Console.WriteLine ();
-			Console.WriteLine ("On Windows, a .vsix file is assumed and .pkg on OSX. Linux is not currently supported.");
-		}
+		static string Version => typeof (Program).Assembly.GetName ().Version.ToString ();
 	}
 }

--- a/Boots/Program.cs
+++ b/Boots/Program.cs
@@ -1,6 +1,7 @@
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.CommandLine.Parsing;
 using System.Threading;
 using System.Threading.Tasks;
 using Boots.Core;
@@ -16,7 +17,7 @@ namespace Boots
 				return;
 			}
 
-			const string options = "Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac and Mono.";
+			const string options = "Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.";
 			var rootCommand = new RootCommand
 			{
 				new Option(
@@ -39,7 +40,8 @@ namespace Boots
 				},
 			};
 			rootCommand.Name = "boots";
-			rootCommand.Description = $"boots {Version}";
+			rootCommand.AddValidator (Validator);
+			rootCommand.Description = $"boots {Version} File issues at: https://github.com/jonathanpeppers/boots/issues";
 			rootCommand.Handler = CommandHandler.Create <string, string, string> (Run);
 			await rootCommand.InvokeAsync (args);
 		}
@@ -52,6 +54,16 @@ namespace Boots
 			} catch (UriFormatException) {
 				return false;
 			}
+		}
+
+		static string Validator (CommandResult result)
+		{
+			if (result.ValueForOption ("--url") == null &&
+				result.ValueForOption ("--stable") == null &&
+				result.ValueForOption ("--preview") == null) {
+				return "At least one of --url, --stable, or --preview must be used";
+			}
+			return "";
 		}
 
 		static async Task Run (string url, string stable = null, string preview = null)

--- a/Cake.Boots/BootsAddin.cs
+++ b/Cake.Boots/BootsAddin.cs
@@ -22,7 +22,7 @@ namespace Cake.Boots
 		}
 
 		[CakeMethodAlias]
-		public static async Task Boots (this ICakeContext context, ReleaseChannel channel, Product product)
+		public static async Task Boots (this ICakeContext context, Product product, ReleaseChannel channel = ReleaseChannel.Stable)
 		{
 			var boots = new Bootstrapper {
 				Channel = channel,

--- a/Cake.Boots/BootsAddin.cs
+++ b/Cake.Boots/BootsAddin.cs
@@ -21,6 +21,18 @@ namespace Cake.Boots
 			await boots.Install ();
 		}
 
+		[CakeMethodAlias]
+		public static async Task Boots (this ICakeContext context, ReleaseChannel channel, Product product)
+		{
+			var boots = new Bootstrapper {
+				Channel = channel,
+				Product = product,
+				Logger = new CakeWriter (context)
+			};
+
+			await boots.Install ();
+		}
+
 		class CakeWriter : TextWriter
 		{
 			const Verbosity verbosity = Verbosity.Normal;

--- a/Cake.Boots/Cake.Boots.csproj
+++ b/Cake.Boots/Cake.Boots.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.34.1" />
+    <PackageReference Include="System.Text.Json" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -17,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(OutputPath)Boots.Core.dll" Pack="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(OutputPath)Boots.Core.pdb" Pack="true" PackagePath="lib\netstandard2.0" />
+    <None Include="$(OutputPath)*.dll" Pack="true" PackagePath="lib\netstandard2.0" Exclude="$(OutputPath)Cake.Boots.dll" />
+    <None Include="$(OutputPath)*.pdb" Pack="true" PackagePath="lib\netstandard2.0" Exclude="$(OutputPath)Cake.Boots.pdb" />
   </ItemGroup>
 
 </Project>

--- a/Cake.Boots/build.cake
+++ b/Cake.Boots/build.cake
@@ -12,6 +12,11 @@ Task("Boots")
         "https://aka.ms/objective-sharpie";
 
     await Boots (url);
+
+    if (!IsRunningOnWindows()) {
+        await Boots (Product.XamariniOS);
+        await Boots (Product.XamarinMac, ReleaseChannel.Preview);
+    }
 });
 
 Task("Default")

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,11 @@
 <Project>
   <PropertyGroup>
-    <BootsVersion Condition=" '$(BootsVersion)' == ''">1.0.1</BootsVersion>
+    <BootsVersion Condition=" '$(BootsVersion)' == ''">1.0.2</BootsVersion>
     <BootsSuffix Condition=" '$(BootsSuffix)' == '' "></BootsSuffix>
     <BuildNumber Condition=" '$(BuildNumber)' == '' And '$(BUILD_BUILDNUMBER)' != '' ">$(BUILD_BUILDNUMBER)</BuildNumber>
     <BuildNumber Condition=" '$(BuildNumber)' == '' ">1</BuildNumber>
     <AssemblyVersion>$(BootsVersion).$(BuildNumber)</AssemblyVersion>
+    <InformationalVersion>$(BootsVersion).$(BuildNumber)</InformationalVersion>
     <PackageVersion>$(BootsVersion).$(BuildNumber)$(BootsSuffix)</PackageVersion>
     <Authors>Jonathan Peppers, Peter Collins</Authors>
     <Copyright>$([System.DateTime]::Now.Year) $(Authors)</Copyright>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,6 @@ variables:
   BootsSuffix: ''
   PackageVersion: $(BootsVersion).$(Build.BuildNumber)$(BootsSuffix)
   Mono.Pkg: https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
-  XA.Vsix: https://aka.ms/xamarin-android-commercial-preview-windows
-  XA.Pkg: https://aka.ms/xamarin-android-commercial-preview-macos
   XA.Version: 10.2
   ShippedBoots: 1.0.1.386
   DotNetCoreVersion: 3.0.100
@@ -32,7 +30,6 @@ jobs:
   - template: scripts/build-and-test.yaml
     parameters:
       platform: windows
-      url: $(XA.Vsix)
 
   - powershell: .\build.ps1
     displayName: Cake test
@@ -58,7 +55,6 @@ jobs:
   - template: scripts/build-and-test.yaml
     parameters:
       platform: mac
-      url: $(XA.Pkg)
 
   - bash: ./build.sh
     displayName: Cake test

--- a/scripts/build-and-test.yaml
+++ b/scripts/build-and-test.yaml
@@ -1,6 +1,5 @@
 parameters:
   platform: ''
-  url: ''
 steps:
 
 - task: MSBuild@1
@@ -21,10 +20,9 @@ steps:
     testRunTitle: ${{ parameters.platform }}
   condition: succeededOrFailed()
 
-- task: Boots@1
+- script: |
+    dotnet Boots/bin/$(Configuration)/netcoreapp3.0/Boots.dll --preview Xamarin.Android
   displayName: install xamarin-android
-  inputs:
-    uri: ${{ parameters.url }}
 
 - task: MSBuild@1
   displayName: verify


### PR DESCRIPTION
This enables commands such as:

    boots --stable Xamarin.Android
    boots --stable Xamarin.iOS
    boots --preview Xamarin.Mac
    boots --preview Mono

Or in a `cake` script:

```csharp
await Boots (Product.Mono);
await Boots (Product.XamariniOS);
await Boots (Product.XamarinAndroid, ReleaseChannel.Stable);
await Boots (Product.XamarinMac, ReleaseChannel.Preview);
```

These commands are possible by using the online manifests the VS updaters use.

### API "docs"

Some examples of using the VS Windows manifests:

* https://github.com/dotnet/aspnetcore/blob/915cc74df832d40b270886b4d2d318d33d072404/eng/scripts/vs.json
* https://docs.microsoft.com/visualstudio/install/automated-installation-with-response-file

An open-source example of the VS Mac manifest:

* https://github.com/microsoft/workbooks/blob/1ef3b233398b03eec326cc4e8bfaa3430426a805/Clients/Xamarin.Interactive.Client/Client/Updater/UpdaterService.cs#L163