### PR TITLE
[macOS] add -dumplog switch to installer command

### DIFF
--- a/Boots.Core/PkgInstaller.cs
+++ b/Boots.Core/PkgInstaller.cs
@@ -20,7 +20,7 @@ namespace Boots.Core
 
 			using (var proc = new AsyncProcess (Boots) {
 				Command = "/usr/sbin/installer",
-				Arguments = $"-pkg \"{file}\" -target / -verbose",
+				Arguments = $"-verbose -dumplog -pkg \"{file}\" -target /",
 				Elevate = true,
 			}) {
 				await proc.RunAsync (token);

--- a/Boots.Tests/BootstrapperTests.cs
+++ b/Boots.Tests/BootstrapperTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Boots.Core;
 using Xunit;
@@ -25,6 +26,14 @@ namespace Boots.Tests
 				Skip.If (true, "Not supported on Linux yet");
 			}
 			await boots.Install ();
+		}
+
+		[SkippableFact]
+		public async Task InvalidInstallerFile ()
+		{
+			Skip.If (!Helpers.IsMac && !Helpers.IsWindows, "Not supported on Linux yet");
+			boots.Url = "https://i.kym-cdn.com/entries/icons/mobile/000/018/012/this_is_fine.jpg";
+			await Assert.ThrowsAsync<Exception> (() => boots.Install ());
 		}
 	}
 }

--- a/Cake.Boots/Cake.Boots.csproj
+++ b/Cake.Boots/Cake.Boots.csproj
@@ -24,14 +24,14 @@
 
   <ItemGroup>
     <!--These are listed explicitly so if they are missing, we get a build error-->
-    <None Include="$(OutputPath)Boots.Core.dll" Pack="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(OutputPath)Boots.Core.pdb" Pack="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(PkgSystem_Buffers)\lib\$(TargetFramework)\System.Buffers.dll" Pack="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(PkgSystem_Memory)\lib\$(TargetFramework)\System.Memory.dll" Pack="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(PkgSystem_Numerics_Vectors)\lib\$(TargetFramework)\System.Numerics.Vectors.dll" Pack="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)\lib\$(TargetFramework)\System.Runtime.CompilerServices.Unsafe.dll" Pack="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(PkgSystem_Text_Encodings_Web)\lib\$(TargetFramework)\System.Text.Encodings.Web.dll" Pack="true" PackagePath="lib\netstandard2.0" />
-    <None Include="$(PkgSystem_Text_Json)\lib\$(TargetFramework)\System.Text.Json.dll" Pack="true" PackagePath="lib\netstandard2.0" />
+    <None Include="$(OutputPath)Boots.Core.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Include="$(OutputPath)Boots.Core.pdb" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Include="$(PkgSystem_Buffers)\lib\$(TargetFramework)\System.Buffers.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Include="$(PkgSystem_Memory)\lib\$(TargetFramework)\System.Memory.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Include="$(PkgSystem_Numerics_Vectors)\lib\$(TargetFramework)\System.Numerics.Vectors.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Include="$(PkgSystem_Runtime_CompilerServices_Unsafe)\lib\$(TargetFramework)\System.Runtime.CompilerServices.Unsafe.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Include="$(PkgSystem_Text_Encodings_Web)\lib\$(TargetFramework)\System.Text.Encodings.Web.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Include="$(PkgSystem_Text_Json)\lib\$(TargetFramework)\System.Text.Json.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
   </ItemGroup>
 
 </Project>

--- a/Cake.Boots/build.cake
+++ b/Cake.Boots/build.cake
@@ -14,6 +14,8 @@ Task("Boots")
     await Boots (url);
 
     if (!IsRunningOnWindows()) {
+        await Boots (Product.Mono);
+        await Boots (Product.XamarinAndroid);
         await Boots (Product.XamariniOS);
         await Boots (Product.XamarinMac, ReleaseChannel.Preview);
     }


### PR DESCRIPTION
I've gotten some reports of pkg files failing to install on macOS
Catalina, something like:

    Querying https://software.xamarin.com/Service/Updates?v=2&pv964ebddd-1ffe-47e7-8128-5ce17ffffb05=0&pv4569c276-1397-4adb-9485-82a7696df22e=0&pvd1ec039f-f3db-468b-a508-896d7c382999=0&pv0ab364ff-c0e9-43a8-8747-3afb02dc7731=0&level=Stable
    Downloading https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg
    Writing to /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/7kjmmg6c.nw4.pkg
    Deleting /var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/7kjmmg6c.nw4.pkg
    An error occurred when executing task 'provision-androidsdk'.
    Error: One or more errors occurred. ('/usr/bin/sudo' with arguments '/usr/sbin/installer -pkg "/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/7kjmmg6c.nw4.pkg" -target / -verbose' exited with code 137)
        '/usr/bin/sudo' with arguments '/usr/sbin/installer -pkg "/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/7kjmmg6c.nw4.pkg" -target / -verbose' exited with code 137

Searching the web, code 137 seems like it means "out of memory".

We definitely don't have any log output, so hoping `-dumplog` will help.

I also made some files not visible in IDEs.