### PR TITLE
Setup nullable reference types

### DIFF
--- a/Boots.Core/AsyncProcess.cs
+++ b/Boots.Core/AsyncProcess.cs
@@ -10,11 +10,11 @@ namespace Boots.Core
 	{
 		readonly Bootstrapper boots;
 
-		public string Command { get; set; }
-		public string Arguments { get; set; }
+		public string Command { get; set; } = "";
+		public string Arguments { get; set; } = "";
 		public bool Elevate { get; set; } = false;
 
-		Process process;
+		Process? process;
 
 		public AsyncProcess (Bootstrapper boots)
 		{
@@ -73,7 +73,7 @@ namespace Boots.Core
 		{
 			int exitCode = await Run (token);
 			if (exitCode != 0)
-				throw new Exception ($"'{Command}' with arguments '{Arguments}' exited with code {process.ExitCode}");
+				throw new Exception ($"'{Command}' with arguments '{Arguments}' exited with code {exitCode}");
 			return exitCode;
 		}
 

--- a/Boots.Core/Boots.Core.csproj
+++ b/Boots.Core/Boots.Core.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Boots.Core/Bootstrapper.cs
+++ b/Boots.Core/Bootstrapper.cs
@@ -14,7 +14,7 @@ namespace Boots.Core
 
 		public Product? Product { get; set; }
 
-		public string Url { get; set; }
+		public string Url { get; set; } = "";
 
 		public TextWriter Logger { get; set; } = Console.Out;
 

--- a/Boots.Core/Downloader.cs
+++ b/Boots.Core/Downloader.cs
@@ -11,7 +11,7 @@ namespace Boots.Core
 		readonly Bootstrapper boots;
 		readonly Uri uri;
 
-		public Downloader (Bootstrapper boots, string extension = null)
+		public Downloader (Bootstrapper boots, string extension = "")
 		{
 			this.boots = boots;
 			uri = new Uri (boots.Url);

--- a/Boots.Core/VsixInstaller.cs
+++ b/Boots.Core/VsixInstaller.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +7,7 @@ namespace Boots.Core
 {
 	class VsixInstaller : Installer
 	{
-		string visualStudioDirectory;
+		string? visualStudioDirectory;
 
 		public VsixInstaller (Bootstrapper boots) : base (boots) { }
 

--- a/Boots.Core/WindowsUrlResolver.cs
+++ b/Boots.Core/WindowsUrlResolver.cs
@@ -26,7 +26,7 @@ namespace Boots.Core
 			var response = await httpClient.GetAsync (uri, token);
 			response.EnsureSuccessStatusCode ();
 
-			string payloadManifestUrl;
+			string? payloadManifestUrl;
 			using (var stream = await response.Content.ReadAsStreamAsync ()) {
 				token.ThrowIfCancellationRequested ();
 				var manifest = await JsonSerializer.DeserializeAsync<VSManifest> (stream, cancellationToken: token);
@@ -49,7 +49,8 @@ namespace Boots.Core
 				token.ThrowIfCancellationRequested ();
 				var payload = await JsonSerializer.DeserializeAsync<VSPayloadManifest> (stream, cancellationToken: token);
 				var url = payload.packages?.FirstOrDefault (p => p.id == productId)?.payloads?.Select (p => p.url).FirstOrDefault ();
-				if (string.IsNullOrEmpty (url)) {
+				// NOTE: workaround NRT in netstandard2.0
+				if (url == null || url == "") {
 					throw new InvalidOperationException ($"Did not find payload url for '{productId}' at: {uri}");
 				}
 
@@ -99,24 +100,24 @@ namespace Boots.Core
 
 		class VSManifest
 		{
-			public VSPackage [] channelItems { get; set; }
+			public VSPackage []? channelItems { get; set; }
 		}
 
 		class VSPayload
 		{
-			public string url { get; set; }
+			public string? url { get; set; }
 		}
 
 		class VSPayloadManifest
 		{
-			public VSPackage [] packages { get; set; }
+			public VSPackage []? packages { get; set; }
 		}
 
 		class VSPackage
 		{
-			public string id { get; set; }
+			public string? id { get; set; }
 
-			public VSPayload [] payloads { get; set; }
+			public VSPayload []? payloads { get; set; }
 		}
 	}
 }

--- a/Boots/Boots.csproj
+++ b/Boots/Boots.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>boots</ToolCommandName>
     <PackageOutputPath>..\bin</PackageOutputPath>

--- a/Boots/Program.cs
+++ b/Boots/Program.cs
@@ -66,7 +66,7 @@ namespace Boots
 			return "";
 		}
 
-		static async Task Run (string url, string stable = null, string preview = null)
+		static async Task Run (string url, string stable = "", string preview = "")
 		{
 			var cts = new CancellationTokenSource ();
 			Console.CancelKeyPress += (sender, e) => cts.Cancel ();
@@ -87,6 +87,6 @@ namespace Boots
 			}
 		}
 
-		static string Version => typeof (Program).Assembly.GetName ().Version.ToString ();
+		static string? Version => typeof (Program).Assembly.GetName ().Version?.ToString ();
 	}
 }

--- a/Cake.Boots/Cake.Boots.csproj
+++ b/Cake.Boots/Cake.Boots.csproj
@@ -1,7 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageOutputPath>..\bin</PackageOutputPath>
     <PackageId>Cake.Boots</PackageId>
     <Title>$(PackageId)</Title>


### PR DESCRIPTION
Context: https://docs.microsoft.com/dotnet/csharp/nullable-references

To properly setup NRT, I added:

    <LangVersion>latest</LangVersion>
    <Nullable>enable</Nullable>
    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

As expected, this found one place that could possibly throw a `NullReferenceException`.

I also had to workaround one spot where `string.IsNullOrEmpty` does not have `[NotNullWhen(false)]` defined in netstandard2.0.