### PR TITLE
[vsix] AlreadyInstalledException should complete successfully

### DIFF
--- a/Boots.Core/AsyncProcess.cs
+++ b/Boots.Core/AsyncProcess.cs
@@ -53,7 +53,7 @@ namespace Boots.Core
 			return Task.Run (process.WaitForExit, token);
 		}
 
-		async Task<int> Run (CancellationToken token = new CancellationToken ())
+		async Task<int> Run (CancellationToken token)
 		{
 			process = CreateProcess ();
 			process.ErrorDataReceived += (sender, e) => {
@@ -69,15 +69,18 @@ namespace Boots.Core
 			return process.ExitCode;
 		}
 
-		public async Task<int> RunAsync (CancellationToken token = new CancellationToken ())
+		public async Task<int> RunAsync (CancellationToken token, bool throwOnError = true)
 		{
 			int exitCode = await Run (token);
-			if (exitCode != 0)
-				throw new Exception ($"'{Command}' with arguments '{Arguments}' exited with code {exitCode}");
+			if (throwOnError && exitCode != 0)
+				ThrowForExitCode (exitCode);
 			return exitCode;
 		}
 
-		public async Task<string> RunWithOutputAsync (CancellationToken token = new CancellationToken ())
+		public void ThrowForExitCode (int exitCode) =>
+			throw new Exception ($"'{Command}' with arguments '{Arguments}' exited with code {exitCode}");
+
+		public async Task<string> RunWithOutputAsync (CancellationToken token)
 		{
 			var builder = new StringBuilder ();
 			process = CreateProcess ();

--- a/Boots.Tests/AsyncProcessTests.cs
+++ b/Boots.Tests/AsyncProcessTests.cs
@@ -34,7 +34,7 @@ namespace Boots.Tests
 			using (var proc = new AsyncProcess (boots) {
 				Command = Guid.NewGuid ().ToString ()
 			}) {
-				await Assert.ThrowsAsync<Win32Exception> (() => proc.RunAsync ());
+				await Assert.ThrowsAsync<Win32Exception> (() => proc.RunAsync (new CancellationToken ()));
 			}
 		}
 
@@ -45,7 +45,7 @@ namespace Boots.Tests
 				Command = Helpers.IsWindows ? "cmd" : "echo",
 				Arguments = Helpers.IsWindows ? "/C echo test" : "test"
 			}) {
-				var text = await proc.RunWithOutputAsync ();
+				var text = await proc.RunWithOutputAsync (new CancellationToken ());
 				Assert.Equal ("test", text.Trim ());
 			}
 		}

--- a/Boots.Tests/BootstrapperTests.cs
+++ b/Boots.Tests/BootstrapperTests.cs
@@ -26,6 +26,8 @@ namespace Boots.Tests
 				Skip.If (true, "Not supported on Linux yet");
 			}
 			await boots.Install ();
+			// Two installs back-to-back should be fine
+			await boots.Install ();
 		}
 
 		[SkippableFact]

--- a/Boots.Tests/Utils.cs
+++ b/Boots.Tests/Utils.cs
@@ -1,8 +1,6 @@
 using System;
 using System.IO;
 using System.Text;
-using Boots.Core;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Boots.Tests
@@ -20,12 +18,16 @@ namespace Boots.Tests
 
 		public override void WriteLine (string value)
 		{
-			output.WriteLine (value ?? "");
+			if (value != null) {
+				output.WriteLine (value);
+				Console.WriteLine (value);
+			}
 		}
 
 		public override void WriteLine (string format, params object [] args)
 		{
 			output.WriteLine (format, args);
+			Console.WriteLine (format, args);
 		}
 	}
 }

--- a/scripts/build-and-test.yaml
+++ b/scripts/build-and-test.yaml
@@ -9,7 +9,7 @@ steps:
     msbuildArguments: '/restore /t:Build,Pack /bl:$(System.DefaultWorkingDirectory)/bin/boots.binlog'
 
 - script: |
-    dotnet vstest Boots.Tests/bin/$(Configuration)/netcoreapp3.0/Boots.Tests.dll --logger:trx
+    dotnet vstest Boots.Tests/bin/$(Configuration)/netcoreapp3.0/Boots.Tests.dll --logger:"trx;verbosity=normal" --logger:"console;verbosity=normal"
   displayName: Run tests
 
 - task: PublishTestResults@2
@@ -18,6 +18,7 @@ steps:
     testResultsFormat: VSTest
     testResultsFiles: TestResults/*.trx
     testRunTitle: ${{ parameters.platform }}
+    failTaskOnFailedTests: true
   condition: succeededOrFailed()
 
 - script: |


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/boots/issues/42

If `VSIXInstaller.exe` returns a 1001 exit code, this means that the `.vsix` is already installed.

I think `boots` should just succeed in this case.

I also made some `CancellationToken` arguments in internal APIs non-optional. This will help not to forget them in the future.