### PR TITLE
[build] expect Xamarin.Android 11.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
   BootsSuffix: ''
   PackageVersion: $(BootsVersion).$(Build.BuildNumber)$(BootsSuffix)
   Mono.Pkg: https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
-  XA.Version: 10.4
+  XA.Version: 11.0
   ShippedBoots: 1.0.2.421
   DotNetCoreVersion: 3.0.100
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true


### PR DESCRIPTION
Should fix:

    /Library/Frameworks/Mono.framework/Versions/6.4.0/lib/mono/msbuild/15.0/bin/MSBuild.dll /nologo /bl:/Users/runner/work/1/s/bin/verify.binlog /p:Expected=10.4 /t:Check /v:minimal /Users/runner/work/1/s/scripts/xa-version.targets
      XamarinAndroidVersion: 11.0.0-3
      Expected: 10.4
    /Users/runner/work/1/s/scripts/xa-version.targets(13,5): error : 11.0.0-3 did not match 10.4