### PR TITLE
Initial dotnet-script support

### DIFF
--- a/Boots.Script/.vscode/launch.json
+++ b/Boots.Script/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Script Debug",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "dotnet",
+            "args": [
+                "exec",
+                "C:/Users/jopepper/.dotnet/tools/.store/dotnet-script/0.53.0/dotnet-script/0.53.0/tools/netcoreapp3.1/any/dotnet-script.dll",
+                "${file}"
+            ],
+            "cwd": "${workspaceRoot}",
+            "stopAtEntry": true
+        }
+    ]
+}

--- a/Boots.Script/Boots.Script.csproj
+++ b/Boots.Script/Boots.Script.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.Build.NoTargets">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <PackageOutputPath>..\bin</PackageOutputPath>
+    <PackageId>Boots.Script</PackageId>
+    <Title>$(PackageId)</Title>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <BootsCoreOutputPath>..\Boots.Core\bin\$(Configuration)\$(TargetFramework)\</BootsCoreOutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Boots.Core\Boots.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--These are listed explicitly so if they are missing, we get a build error-->
+    <None Include="$(BootsCoreOutputPath)Boots.Core.dll" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Include="$(BootsCoreOutputPath)Boots.Core.pdb" Pack="true" PackagePath="lib\netstandard2.0" Visible="false" />
+    <None Update="boots.csx" Pack="true" PackagePath="contentFiles\csx\netstandard2.0\main.csx" />
+  </ItemGroup>
+
+  </Project>

--- a/Boots.Script/boots.csx
+++ b/Boots.Script/boots.csx
@@ -1,0 +1,23 @@
+#r "../../../lib/netstandard2.0/Boots.Core.dll"
+
+using System.Threading.Tasks;
+using Boots.Core;
+
+public static async Task boots (string url)
+{
+	var boots = new Bootstrapper {
+		Url = url,
+	};
+
+	await boots.Install ();
+}
+
+public static async Task boots (Product product, ReleaseChannel channel = ReleaseChannel.Stable)
+{
+	var boots = new Bootstrapper {
+		Channel = channel,
+		Product = product,
+	};
+
+	await boots.Install ();
+}

--- a/Boots.Script/main.csx
+++ b/Boots.Script/main.csx
@@ -1,0 +1,4 @@
+#!/usr/bin/env dotnet-script
+#load "nuget: Boots.Script, 1.0.2.1"
+
+await boots (Product.XamarinAndroid);

--- a/Boots.Script/omnisharp.json
+++ b/Boots.Script/omnisharp.json
@@ -1,0 +1,6 @@
+{
+  "script": {
+    "enableScriptNuGetReferences": true,
+    "defaultTargetFramework": "netcoreapp3.1"
+  }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,8 @@ variables:
   BootsSuffix: ''
   PackageVersion: $(BootsVersion).$(Build.BuildNumber)$(BootsSuffix)
   Mono.Pkg: https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.198.macos10.xamarin.universal.pkg
-  XA.Version: 11.0
+  XA.StableVersion: 11.0
+  XA.PreviewVersion: 11.1
   ShippedBoots: 1.0.2.421
   DotNetCoreVersion: 3.0.100
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,8 @@ jobs:
     name: Hosted Windows 2019 with VS2019
     demands:
     - msbuild
+  variables:
+    BinDirectory: $(System.DefaultWorkingDirectory)\bin\
   steps:
 
   - template: scripts/build-and-test.yaml
@@ -40,6 +42,8 @@ jobs:
   pool:
     name: Hosted macOS
     demands: msbuild
+  variables:
+    BinDirectory: $(System.DefaultWorkingDirectory)/bin/
   steps:
 
   - task: UseDotNet@2

--- a/boots.sln
+++ b/boots.sln
@@ -9,7 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Boots", "Boots\Boots.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Boots.Tests", "Boots.Tests\Boots.Tests.csproj", "{393FF93B-5A0B-490E-9E28-4B38E579AF7C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Boots", "Cake.Boots\Cake.Boots.csproj", "{10B653C6-675D-49D1-8BA6-DC62F2131742}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cake.Boots", "Cake.Boots\Cake.Boots.csproj", "{10B653C6-675D-49D1-8BA6-DC62F2131742}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Boots.Script", "Boots.Script\Boots.Script.csproj", "{103AD2B3-BE1A-4A5A-BB43-E4C0505F0D43}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{10B653C6-675D-49D1-8BA6-DC62F2131742}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{10B653C6-675D-49D1-8BA6-DC62F2131742}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{10B653C6-675D-49D1-8BA6-DC62F2131742}.Release|Any CPU.Build.0 = Release|Any CPU
+		{103AD2B3-BE1A-4A5A-BB43-E4C0505F0D43}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{103AD2B3-BE1A-4A5A-BB43-E4C0505F0D43}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{103AD2B3-BE1A-4A5A-BB43-E4C0505F0D43}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{103AD2B3-BE1A-4A5A-BB43-E4C0505F0D43}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+    "msbuild-sdks": {
+        "Microsoft.Build.NoTargets": "2.0.1"
+    }
+}

--- a/scripts/build-and-test.yaml
+++ b/scripts/build-and-test.yaml
@@ -22,14 +22,24 @@ steps:
   condition: succeededOrFailed()
 
 - script: |
-    dotnet Boots/bin/$(Configuration)/netcoreapp3.0/Boots.dll --preview Xamarin.Android
-  displayName: install xamarin-android
+    dotnet script Boots.Script/main.csx --no-cache -s $(System.DefaultWorkingDirectory)/bin/
+  displayName: dotnet-script xamarin-android stable
 
 - task: MSBuild@1
   displayName: verify
   inputs:
     solution: scripts/xa-version.targets
-    msbuildArguments: '/v:minimal /nologo /t:Check /p:Expected=$(XA.Version) /bl:$(System.DefaultWorkingDirectory)/bin/verify.binlog'
+    msbuildArguments: '/v:minimal /nologo /t:Check /p:Expected=$(XA.StableVersion) /bl:$(System.DefaultWorkingDirectory)/bin/verify-stable.binlog'
+
+- script: |
+    dotnet Boots/bin/$(Configuration)/netcoreapp3.0/Boots.dll --preview Xamarin.Android
+  displayName: boots xamarin-android preview
+
+- task: MSBuild@1
+  displayName: verify
+  inputs:
+    solution: scripts/xa-version.targets
+    msbuildArguments: '/v:minimal /nologo /t:Check /p:Expected=$(XA.PreviewVersion) /bl:$(System.DefaultWorkingDirectory)/bin/verify-preview.binlog'
 
 - task: MSBuild@1
   displayName: build sample

--- a/scripts/build-and-test.yaml
+++ b/scripts/build-and-test.yaml
@@ -22,8 +22,9 @@ steps:
   condition: succeededOrFailed()
 
 - script: |
+    echo "$(BinDirectory)"
     dotnet tool install -g dotnet-script
-    dotnet script Boots.Script/main.csx --no-cache -s $(System.DefaultWorkingDirectory)/bin/
+    dotnet script Boots.Script/main.csx --verbosity trace --no-cache -s $(BinDirectory)
   displayName: dotnet-script xamarin-android stable
 
 - task: MSBuild@1

--- a/scripts/build-and-test.yaml
+++ b/scripts/build-and-test.yaml
@@ -22,6 +22,7 @@ steps:
   condition: succeededOrFailed()
 
 - script: |
+    dotnet tool install -g dotnet-script
     dotnet script Boots.Script/main.csx --no-cache -s $(System.DefaultWorkingDirectory)/bin/
   displayName: dotnet-script xamarin-android stable
 


### PR DESCRIPTION
Context: https://github.com/filipw/dotnet-script

This creates a new Boots.Script package that can be used with
`dotnet-script` such as:

    dotnet tool install -g dotnet-script
    dotnet script init

Then edit `main.csx`:

    #!/usr/bin/env dotnet-script
    #load "nuget: Boots.Script, 1.0.2.1"
    await boots (Product.XamarinAndroid);

`dotnet script main.csx` or `./main.csx` on Unix-like systems would
install Xamarin.Android!

Documentation for this to follow, when there is a useable release of
Boots.Script on NuGet.