### PR TITLE
[boots] fix help text

### DIFF
--- a/Boots/Program.cs
+++ b/Boots/Program.cs
@@ -30,13 +30,13 @@ namespace Boots
 					"--stable",
 					$"Install the latest *stable* version of a product from VS manifests. {options}")
 				{
-					Argument = new Argument<string>()
+					Argument = new Argument<string>("product")
 				},
 				new Option(
 					"--preview",
 					$"Install the latest *preview* version of a product from VS manifests. {options}")
 				{
-					Argument = new Argument<string>()
+					Argument = new Argument<string>("product")
 				},
 			};
 			rootCommand.Name = "boots";

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Usage:
 
 Options:
   --url <url>            A URL to a pkg or vsix file to install
-  --stable <stable>      Install the latest *stable* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.
-  --preview <preview>    Install the latest *preview* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.
+  --stable <product>     Install the latest *stable* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.
+  --preview <product>    Install the latest *preview* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.
   --version              Display version information
 ```
 


### PR DESCRIPTION
Instead of `<stable>` and `<preview>`:

    --stable <stable>      Install the latest *stable* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.
    --preview <preview>    Install the latest *preview* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.

`boots` should print:

    --stable <product>     Install the latest *stable* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.
    --preview <product>    Install the latest *preview* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.