### PR TITLE
Add attribute for Cake alias category

### DIFF
--- a/Cake.Boots/BootsAddin.cs
+++ b/Cake.Boots/BootsAddin.cs
@@ -8,6 +8,7 @@ using Cake.Core.Diagnostics;
 
 namespace Cake.Boots
 {
+	[CakeAliasCategory("Boots")]
 	public static class BootsAddin
 	{
 		[CakeMethodAlias]


### PR DESCRIPTION
Add attribute for Cake alias category which will list be used to list the aliases on the DSL reference page at https://cakebuild.net/dsl/ and on the addin detail page at https://cakebuild.net/extensions/cake-boots/