### PR TITLE
[actions] use setup-dotnet

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,9 +10,6 @@ on:
     paths:
     - '.github/**'
 
-env:
-  boots_version: 1.0.2.421
-
 jobs:
   macOS:
     runs-on: macOS-latest
@@ -27,7 +24,7 @@ jobs:
       shell: bash
       run: |
         export PATH="$PATH:~/.dotnet/tools"
-        dotnet tool install --global boots --version $boots_version
+        dotnet tool install --global boots
         boots --preview Mono
         boots --preview XamarinAndroid
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage
@@ -42,6 +39,6 @@ jobs:
     - name: build
       shell: pwsh
       run: |
-        dotnet tool install --global boots --version $env:boots_version
+        dotnet tool install --global boots
         boots --preview XamarinAndroid
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -20,11 +20,12 @@ jobs:
       DOTNET_CLI_TELEMETRY_OPTOUT: 'true'
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.0.x'
     - name: build
       shell: bash
       run: |
-        wget https://dot.net/v1/dotnet-install.sh
-        sh dotnet-install.sh -Version 3.0.100
         export PATH="$PATH:~/.dotnet/tools"
         dotnet tool install --global boots --version $boots_version
         boots --preview Mono


### PR DESCRIPTION
This way we aren't using `dotnet-install.sh` ourselves, it appears to
be failing now:

    --2020-10-26 14:47:11--  https://dot.net/v1/dotnet-install.sh
    Resolving dot.net (dot.net)... 40.113.200.201, 13.77.161.179, 104.215.148.63, ...
    Connecting to dot.net (dot.net)|40.113.200.201|:443... connected.
    HTTP request sent, awaiting response... 301 Moved Permanently
    Location: https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh [following]
    --2020-10-26 14:47:12--  https://dotnet.microsoft.com/download/dotnet-core/scripts/v1/dotnet-install.sh
    Resolving dotnet.microsoft.com (dotnet.microsoft.com)... 13.107.246.10
    Connecting to dotnet.microsoft.com (dotnet.microsoft.com)|13.107.246.10|:443... connected.
    HTTP request sent, awaiting response... 200 OK
    Length: 36458 (36K) [application/x-sh]
    Saving to: ‘dotnet-install.sh’

         0K .......... .......... .......... .....                100% 90.5M=0s

    2020-10-26 14:47:12 (90.5 MB/s) - ‘dotnet-install.sh’ saved [36458/36458]

    ##[error]Process completed with exit code 22.