### PR TITLE
[build] use $(RollForward) Major instead of multi-targeting

### DIFF
--- a/Boots/Boots.csproj
+++ b/Boots/Boots.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <RollForward>Major</RollForward>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
Context: https://natemcmaster.com/blog/2019/01/09/netcore-primitives-3/
Context: https://github.com/dotnet/designs/blob/main/accepted/2019/runtime-binding.md#rollforward

Previously when running `boots` on a machine with *only* .NET 5.0 and
no .NET Core 3.1, you could hit:

    It was not possible to find any compatible framework version
    The framework 'Microsoft.NETCore.App', version '3.1.0' was not found.

To solve this, we need our `*.runtimeconfig.json` to allow things to
automatically roll forward to .NET 5.0 if .NET Core 3.1 is not found.

If we set `$(RollForward)` to `Major`:

> `Major` -- Roll forward to lowest higher major version, and lowest
> minor version, if requested major version is missing. If the
> requested major version is present, then the `Minor` policy is used.

I think this will make things work indefinitely for new .NET versions.
I don't think this tool is likely to break on newer versions, and the
older one will be used if found.