### PR TITLE
Fix `boots` command-line arguments

### DIFF
--- a/Boots.Tests/Boots.Tests.csproj
+++ b/Boots.Tests/Boots.Tests.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Boots.Core\Boots.Core.csproj" />
+    <ProjectReference Include="..\Boots\Boots.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Boots.Tests/MainTests.cs
+++ b/Boots.Tests/MainTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Boots.Tests
+{
+	public class MainTests : IDisposable
+	{
+		const string DefaultErrorMessage = "At least one of --url, --stable, or --preview must be used";
+		readonly TextWriter consoleError;
+		readonly StringWriter stderr;
+		readonly MethodInfo main;
+
+		public MainTests ()
+		{
+			consoleError = Console.Error;
+			Console.SetError (stderr = new StringWriter ());
+
+			var program = Type.GetType ("Boots.Program, Boots", throwOnError: true);
+			main = program.GetMethod ("Main", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+			Assert.NotNull (main);
+		}
+
+		public void Dispose ()
+		{
+			Console.SetError (consoleError);
+		}
+
+		[Fact]
+		public async Task Empty ()
+		{
+			var args = Array.Empty<string> ();
+			var task = (Task) main.Invoke (null, new object [] { args });
+			await task;
+			Assert.Contains (DefaultErrorMessage, stderr.ToString ());
+		}
+
+		[Fact]
+		public async Task Stable ()
+		{
+			var args = new [] { "--stable", "Xamarin.Android" };
+			var task = (Task) main.Invoke (null, new object [] { args });
+			await task;
+			Assert.DoesNotContain (DefaultErrorMessage, stderr.ToString ());
+		}
+	}
+}

--- a/Boots/Program.cs
+++ b/Boots/Program.cs
@@ -64,9 +64,9 @@ namespace Boots
 
 		static string Validator (CommandResult result)
 		{
-			if (result.GetArgumentValueOrDefault ("--url") == null &&
-				result.GetArgumentValueOrDefault ("--stable") == null &&
-				result.GetArgumentValueOrDefault ("--preview") == null) {
+			if (result.OptionResult ("--url") == null &&
+				result.OptionResult ("--stable") == null &&
+				result.OptionResult ("--preview") == null) {
 				return "At least one of --url, --stable, or --preview must be used";
 			}
 			return "";

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
I noticed this on CI:

    > dotnet Boots/bin/$(Configuration)/netcoreapp3.1/Boots.dll --preview Xamarin.Android
    At least one of --url, --stable, or --preview must be used

What? `--preview` was passed???

This broke in 674d09b6e, when I used the wrong API for validating
incoming command-line options...

I will delist 1.0.3.551.

To prevent this in the future, I added `MainTests` that actually check
that the `static Task Main()` returns the proper output and works
correctly.