### PR TITLE
Add --timeout switch

### DIFF
--- a/Boots.Core/Bootstrapper.cs
+++ b/Boots.Core/Bootstrapper.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -10,6 +11,8 @@ namespace Boots.Core
 {
 	public class Bootstrapper
 	{
+		public TimeSpan? Timeout { get; set; }
+
 		public ReleaseChannel? Channel { get; set; }
 
 		public Product? Product { get; set; }
@@ -62,6 +65,15 @@ namespace Boots.Core
 				await downloader.Download (token);
 				await installer.Install (downloader.TempFile, token);
 			}
+		}
+
+		internal HttpClient GetHttpClient ()
+		{
+			var httpClient = new HttpClient ();
+			if (Timeout != null) {
+				httpClient.Timeout = Timeout.Value;
+			}
+			return httpClient;
 		}
 	}
 }

--- a/Boots.Core/Downloader.cs
+++ b/Boots.Core/Downloader.cs
@@ -23,19 +23,19 @@ namespace Boots.Core
 
 		public async Task Download (CancellationToken token = new CancellationToken ())
 		{
-			using (var client = new HttpClient ()) {
-				boots.Logger.WriteLine ($"Downloading {uri}");
-				var request = new HttpRequestMessage (HttpMethod.Get, uri);
-				var response = await client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead, token);
-				response.EnsureSuccessStatusCode ();
-				using (var httpStream = await response.Content.ReadAsStreamAsync ()) {
-					token.ThrowIfCancellationRequested ();
-					using (var fileStream = File.Create (TempFile)) {
-						boots.Logger.WriteLine ($"Writing to {TempFile}");
-						await httpStream.CopyToAsync (fileStream, 8 * 1024, token);
-					}
-				}
-			}
+			boots.Logger.WriteLine ($"Downloading {uri}");
+
+			using HttpClient client = boots.GetHttpClient ();
+			var request = new HttpRequestMessage (HttpMethod.Get, uri);
+			var response = await client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead, token);
+			response.EnsureSuccessStatusCode ();
+
+			using var httpStream = await response.Content.ReadAsStreamAsync ();
+			token.ThrowIfCancellationRequested ();
+
+			using var fileStream = File.Create (TempFile);
+			boots.Logger.WriteLine ($"Writing to {TempFile}");
+			await httpStream.CopyToAsync (fileStream, 8 * 1024, token);
 		}
 
 		public void Dispose ()

--- a/Boots.Core/MacUrlResolver.cs
+++ b/Boots.Core/MacUrlResolver.cs
@@ -17,12 +17,11 @@ namespace Boots.Core
 			{ Product.XamarinMac,     "0ab364ff-c0e9-43a8-8747-3afb02dc7731" },
 		};
 
-		readonly HttpClient httpClient = new HttpClient ();
-
 		public MacUrlResolver (Bootstrapper boots) : base (boots) { }
 
 		public async override Task<string> Resolve (ReleaseChannel channel, Product product, CancellationToken token = new CancellationToken ())
 		{
+			using HttpClient httpClient = Boots.GetHttpClient ();
 			string level = GetLevel (channel);
 			string productId = GetProductId (product);
 

--- a/Boots.Core/WindowsUrlResolver.cs
+++ b/Boots.Core/WindowsUrlResolver.cs
@@ -12,12 +12,11 @@ namespace Boots.Core
 		const string ReleaseUrl = "https://aka.ms/vs/16/release/channel";
 		const string PreviewUrl = "https://aka.ms/vs/16/pre/channel";
 
-		readonly HttpClient httpClient = new HttpClient ();
-
 		public WindowsUrlResolver (Bootstrapper boots) : base (boots) { }
 
 		public async override Task<string> Resolve (ReleaseChannel channel, Product product, CancellationToken token = new CancellationToken ())
 		{
+			using HttpClient httpClient = Boots.GetHttpClient ();
 			Uri uri = GetUri (channel);
 			string channelId = GetChannelId (channel);
 			string productId = GetProductId (product);

--- a/Boots.Tests/BootstrapperTests.cs
+++ b/Boots.Tests/BootstrapperTests.cs
@@ -48,5 +48,23 @@ namespace Boots.Tests
 			boots.Url = "https://i.kym-cdn.com/entries/icons/mobile/000/018/012/this_is_fine.jpg";
 			await Assert.ThrowsAsync<Exception> (() => boots.Install ());
 		}
+
+		[Fact]
+		public void InvalidTimeout ()
+		{
+			var boots = new Bootstrapper {
+				Timeout = TimeSpan.FromSeconds (-1),
+			};
+			Assert.Throws<ArgumentOutOfRangeException> (() => boots.GetHttpClient ());
+		}
+
+		[Fact]
+		public void DefaultTimeout ()
+		{
+			// Mainly validates the 100-second default:
+			// https://docs.microsoft.com/dotnet/api/system.net.http.httpclient.timeout#remarks
+			var boots = new Bootstrapper ();
+			Assert.Equal (TimeSpan.FromSeconds (100), boots.GetHttpClient ().Timeout);
+		}
 	}
 }

--- a/Boots/Program.cs
+++ b/Boots/Program.cs
@@ -44,11 +44,16 @@ namespace Boots
 				{
 					Argument = new Argument<FileType>("file-type")
 				},
+				new Option ("--timeout",
+					$"Specifies a timeout (in seconds) for HttpClient. If omitted, uses the .NET default of 100 seconds.")
+				{
+					Argument = new Argument<double>("timeout")
+				},
 			};
 			rootCommand.Name = "boots";
 			rootCommand.AddValidator (Validator);
 			rootCommand.Description = $"boots {Version} File issues at: https://github.com/jonathanpeppers/boots/issues";
-			rootCommand.Handler = CommandHandler.Create <string, string, string, FileType?> (Run);
+			rootCommand.Handler = CommandHandler.Create <string, string, string, FileType?, double?> (Run);
 			await rootCommand.InvokeAsync (args);
 		}
 
@@ -72,7 +77,7 @@ namespace Boots
 			return "";
 		}
 
-		static async Task Run (string url, string stable = "", string preview = "", FileType? fileType = null)
+		static async Task Run (string url, string stable = "", string preview = "", FileType? fileType = null, double? timeout = null)
 		{
 			var cts = new CancellationTokenSource ();
 			Console.CancelKeyPress += (sender, e) => cts.Cancel ();
@@ -81,6 +86,9 @@ namespace Boots
 				Url = url,
 				FileType = fileType,
 			};
+			if (timeout != null) {
+				boots.Timeout = TimeSpan.FromSeconds (timeout.Value);
+			}
 			SetChannelAndProduct (boots, preview, ReleaseChannel.Preview);
 			SetChannelAndProduct (boots, stable,  ReleaseChannel.Stable);
 			await boots.Install (cts.Token);


### PR DESCRIPTION
Might help: https://github.com/jonathanpeppers/boots/issues/61

* `--timeout` sets the `Timeout` property on all instances of `HttpClient`.
* Reworks `HttpClient` usage so all are created/disposed with `using`.
* Flattened a couple `using`-blocks and used `using var` instead.