### PR TITLE
Add logging on retries

### DIFF
--- a/Boots.Core/Bootstrapper.cs
+++ b/Boots.Core/Bootstrapper.cs
@@ -36,7 +36,8 @@ namespace Boots.Core
 			ActivePolicy = Policy
 				.Handle<HttpRequestException> ()
 				.Or<TimeoutRejectedException> ()
-				.RetryAsync (NetworkRetries)
+				.RetryAsync (NetworkRetries,
+					(exc, count) => Logger.WriteLine ($"Retry attempt {count}: {exc}"))
 				.WrapAsync (Policy.TimeoutAsync (ReadWriteTimeout));
 		}
 


### PR DESCRIPTION
Expanding upon 607adb08, boots should log something like this on retries:

    Logger.WriteLine ($"Retry attempt {count}: {exc}")

So there is actual insight to what is happening!

Updated some tests to verify what happens when different exception types are thrown.