### PR TITLE
[build] consolidate NuGet packaging settings

### DIFF
--- a/Boots/Boots.csproj
+++ b/Boots/Boots.csproj
@@ -6,9 +6,7 @@
     <RollForward>Major</RollForward>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>boots</ToolCommandName>
-    <PackageOutputPath>..\bin</PackageOutputPath>
     <PackageId>boots</PackageId>
-    <Title>$(PackageId)</Title>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Cake.Boots/Cake.Boots.csproj
+++ b/Cake.Boots/Cake.Boots.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageOutputPath>..\bin</PackageOutputPath>
     <PackageId>Cake.Boots</PackageId>
-    <Title>$(PackageId)</Title>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <_NuGetPackagePath>lib\$(TargetFramework)</_NuGetPackagePath>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,11 @@
 <Project>
-  <!-- NuGet packages -->
+  <!-- NuGet packaging settings -->
+  <PropertyGroup Condition=" '$(PackageId)' != '' ">
+    <Title>$(PackageId)</Title>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageOutputPath>$(MSBuildThisFileDirectory)bin</PackageOutputPath>
+  </PropertyGroup>
+  <!-- NuGet dependencies -->
   <ItemGroup>
     <PackageReference Update="Cake.Core"                              Version="1.0.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                 Version="16.8.3" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ build_script:
 - sh: >-
     dotnet tool update --global Cake.Tool &&
     dotnet build boots.sln &&
-    dotnet pack boots.sln &&
     cd Cake.Boots &&
     dotnet cake --target=Mono &&
     dotnet cake

--- a/scripts/build-and-test.yaml
+++ b/scripts/build-and-test.yaml
@@ -8,9 +8,6 @@ steps:
 - script: dotnet build boots.sln -bl:$(System.DefaultWorkingDirectory)/bin/build.binlog
   displayName: dotnet build
 
-- script: dotnet pack boots.sln --no-restore -bl:$(System.DefaultWorkingDirectory)/bin/pack.binlog
-  displayName: dotnet pack
-
 - script: dotnet vstest Boots.Tests/bin/$(Configuration)/netcoreapp3.1/Boots.Tests.dll --logger:"trx;verbosity=normal" --logger:"console;verbosity=normal"
   displayName: dotnet vstest
 


### PR DESCRIPTION
* Use $(GeneratePackageOnBuild), so we don't need `dotnet pack`
* Consolidate a few more settings in `Directory.Build.targets`