### PR TITLE
Implement .exe's

### DIFF
--- a/Boots.Core/Bootstrapper.cs
+++ b/Boots.Core/Bootstrapper.cs
@@ -68,6 +68,9 @@ namespace Boots.Core
 					if (Url.EndsWith (".msi", StringComparison.OrdinalIgnoreCase)) {
 						FileType = global::FileType.msi;
 						Logger.WriteLine ("Inferring .msi from URL.");
+					} else if (Url.EndsWith (".exe", StringComparison.OrdinalIgnoreCase)) {
+						FileType = global::FileType.exe;
+						Logger.WriteLine ("Inferring .exe from URL.");
 					} else if (Url.EndsWith (".vsix", StringComparison.OrdinalIgnoreCase)) {
 						FileType = global::FileType.vsix;
 						Logger.WriteLine ("Inferring .vsix from URL.");
@@ -75,6 +78,8 @@ namespace Boots.Core
 				}
 				if (FileType == global::FileType.msi) {
 					installer = new MsiInstaller (this);
+				} else if (FileType == global::FileType.exe) {
+					installer = new ExeInstaller (this);
 				} else {
 					installer = new VsixInstaller (this);
 				}

--- a/Boots.Core/ExeInstaller.cs
+++ b/Boots.Core/ExeInstaller.cs
@@ -1,0 +1,34 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Boots.Core
+{
+	class ExeInstaller : Installer
+	{
+		public ExeInstaller (Bootstrapper boots) : base (boots) { }
+
+		public override string Extension => ".exe";
+
+		public async override Task Install (string file, CancellationToken token = default)
+		{
+			if (string.IsNullOrEmpty (file))
+				throw new ArgumentException (nameof (file));
+			if (!File.Exists (file))
+				throw new FileNotFoundException ($"{Extension} file did not exist: {file}", file);
+
+			var log = Path.GetTempFileName ();
+			try {
+				using var proc = new AsyncProcess (Boots) {
+					Command = file,
+					Arguments = $"/install /quiet /norestart /log \"{log}\"",
+					Elevate = true,
+				};
+				await proc.RunAsync (token);
+			} finally {
+				await PrintLogFileAndDelete (log, token);
+			}
+		}
+	}
+}

--- a/Boots.Core/FileType.cs
+++ b/Boots.Core/FileType.cs
@@ -2,5 +2,6 @@ public enum FileType
 {
 	vsix,
 	pkg,
-	msi
+	msi,
+	exe
 }

--- a/Boots.Tests/BootstrapperTests.cs
+++ b/Boots.Tests/BootstrapperTests.cs
@@ -42,6 +42,17 @@ namespace Boots.Tests
 		}
 
 		[SkippableFact]
+		public async Task InstallExe ()
+		{
+			Skip.If (!Helpers.IsWindows, ".exes are only supported on Windows");
+			boots.FileType = FileType.exe;
+			boots.Url = "https://download.visualstudio.microsoft.com/download/pr/2290b039-85d8-4d95-85f7-edbd9fcd118d/a64bef89625bc61db2a6832878610214/dotnet-sdk-6.0.100-preview.2.21155.3-win-x64.exe";
+			await boots.Install ();
+			// Two installs back-to-back should be fine
+			await boots.Install ();
+		}
+
+		[SkippableFact]
 		public async Task InvalidInstallerFile ()
 		{
 			Skip.If (!Helpers.IsMac && !Helpers.IsWindows, "Not supported on Linux yet");

--- a/Boots.Tests/BootstrapperTests.cs
+++ b/Boots.Tests/BootstrapperTests.cs
@@ -41,16 +41,16 @@ namespace Boots.Tests
 			await boots.Install ();
 		}
 
-		[SkippableFact]
-		public async Task InstallExe ()
-		{
-			Skip.If (!Helpers.IsWindows, ".exes are only supported on Windows");
-			boots.FileType = FileType.exe;
-			boots.Url = "https://download.visualstudio.microsoft.com/download/pr/2290b039-85d8-4d95-85f7-edbd9fcd118d/a64bef89625bc61db2a6832878610214/dotnet-sdk-6.0.100-preview.2.21155.3-win-x64.exe";
-			await boots.Install ();
-			// Two installs back-to-back should be fine
-			await boots.Install ();
-		}
+		// [SkippableFact]
+		// public async Task InstallExe ()
+		// {
+		// 	Skip.If (!Helpers.IsWindows, ".exes are only supported on Windows");
+		// 	boots.FileType = FileType.exe;
+		// 	boots.Url = "https://download.visualstudio.microsoft.com/download/pr/2290b039-85d8-4d95-85f7-edbd9fcd118d/a64bef89625bc61db2a6832878610214/dotnet-sdk-6.0.100-preview.2.21155.3-win-x64.exe";
+		// 	await boots.Install ();
+		// 	// Two installs back-to-back should be fine
+		// 	await boots.Install ();
+		// }
 
 		[SkippableFact]
 		public async Task InvalidInstallerFile ()

--- a/Boots/Program.cs
+++ b/Boots/Program.cs
@@ -40,7 +40,7 @@ namespace Boots
 				},
 				new Option(
 					"--file-type",
-					$"Specifies the type of file to be installed such as vsix, pkg, or msi. Defaults to vsix on Windows and pkg on macOS.")
+					$"Specifies the type of file to be installed such as vsix, pkg, msi, or exe. Inferred from URL, or defaults to vsix on Windows and pkg on macOS.")
 				{
 					Argument = new Argument<FileType>("file-type")
 				},

--- a/Cake.Boots/build.cake
+++ b/Cake.Boots/build.cake
@@ -24,6 +24,10 @@ Task("Boots")
         var firefox = "https://download-installer.cdn.mozilla.net/pub/firefox/releases/82.0/win64/en-US/Firefox%20Setup%2082.0.msi";
         await Boots (firefox);
         await Boots (firefox, fileType: FileType.msi);
+        // Install .NET 6 twice
+        var dotnet = "https://download.visualstudio.microsoft.com/download/pr/2290b039-85d8-4d95-85f7-edbd9fcd118d/a64bef89625bc61db2a6832878610214/dotnet-sdk-6.0.100-preview.2.21155.3-win-x64.exe";
+        await Boots (dotnet);
+        await Boots (dotnet, fileType: FileType.exe);
     } else {
         // Let's really run through the gauntlet and install 6 .pkg files
         await Boots (Product.XamariniOS,     ReleaseChannel.Stable);

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Options:
   --url <url>                       A URL to a pkg or vsix file to install
   --stable <product>                Install the latest *stable* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.
   --preview <product>               Install the latest *preview* version of a product from VS manifests. Options include: Xamarin.Android, Xamarin.iOS, Xamarin.Mac, and Mono.
-  --file-type <msi|pkg|vsix>        Specifies the type of file to be installed such as vsix, pkg, or msi. Defaults to vsix on Windows and pkg on macOS.
+  --file-type <exe|msi|pkg|vsix>    Specifies the type of file to be installed such as vsix, pkg, msi, or exe. Inferred from URL, or defaults to vsix on Windows and pkg on macOS.
   --timeout <seconds>               Specifies a timeout for HttpClient. If omitted, uses the .NET default of 100 seconds.
   --read-write-timeout <seconds>    Specifies a timeout for reading/writing from a HttpClient stream. If omitted, uses a default of 300 seconds.
   --retries <int>                   Specifies a number of retries for HttpClient failures. If omitted, uses a default of 3 retries.


### PR DESCRIPTION
This allows installation of .NET 6, such as  files from:

* https://dotnet.microsoft.com/download/dotnet/6.0
* https://download.visualstudio.microsoft.com/download/pr/2290b039-85d8-4d95-85f7-edbd9fcd118d/a64bef89625bc61db2a6832878610214/dotnet-sdk-6.0.100-preview.2.21155.3-win-x64.exe

Not every possible `.exe` will work, only those that accept these arguments:

    /install /quiet /norestart /log {file}

I'm not aware of other `.exe` installers, if these arguments are common -- or if they would only work when installing .NET.