### PR TITLE
[gh actions] set $JI_JAVA_HOME

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -27,6 +27,7 @@ jobs:
         dotnet tool install --global boots
         boots --preview Mono
         boots --preview XamarinAndroid
+        export JI_JAVA_HOME="$JAVA_HOME_11_X64"
         msbuild ./samples/HelloForms.Android/HelloForms.Android.csproj /restore /t:SignAndroidPackage
 
   windows:


### PR DESCRIPTION
I think this is the same issue that happens on Azure DevOps, where we are trying to use Java 14 by default.