### PR TITLE
[build] remove $JI_JAVA_HOME

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,9 +37,6 @@ jobs:
     demands: msbuild
   steps:
 
-  - script: echo '##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_11_X64)'
-    displayName: set JI_JAVA_HOME
-
   - template: scripts/build-and-test.yaml
     parameters:
       platform: mac

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,7 @@ jobs:
   - template: scripts/build-and-test.yaml
     parameters:
       platform: windows
+      xamarinAndroidUrl: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4842306/main/bf63c3d116b38459678cb3aefd2f5826e78c385e/signed/Xamarin.Android.Sdk-11.3.99.57.vsix
 
   - powershell: dotnet cake
     displayName: Cake test
@@ -40,6 +41,7 @@ jobs:
   - template: scripts/build-and-test.yaml
     parameters:
       platform: mac
+      xamarinAndroidUrl: https://dl.internalx.com/vsts-devdiv/Xamarin.Android/public/4842306/main/bf63c3d116b38459678cb3aefd2f5826e78c385e/xamarin.android-11.3.99.57.pkg
 
   - bash: dotnet cake --target=Mono && dotnet cake
     workingDirectory: Cake.Boots

--- a/scripts/build-and-test.yaml
+++ b/scripts/build-and-test.yaml
@@ -1,5 +1,6 @@
 parameters:
   platform: ''
+  xamarinAndroidUrl: ''
 steps:
 
 - script: dotnet tool update --global Cake.Tool
@@ -20,7 +21,7 @@ steps:
     failTaskOnFailedTests: true
   condition: succeededOrFailed()
 
-- script: dotnet Boots/bin/$(Configuration)/netcoreapp3.1/Boots.dll --preview Xamarin.Android
+- script: dotnet Boots/bin/$(Configuration)/netcoreapp3.1/Boots.dll ${{ parameters.xamarinAndroidUrl }}
   displayName: install xamarin-android
 
 - task: MSBuild@1


### PR DESCRIPTION
`boots --preview Xamarin.Android` should install a newer Xamarin.Android version now where this fix isn't needed.