### PR TITLE
[tests] add test for JDK 11 .msi

### DIFF
--- a/Boots.Tests/BootstrapperTests.cs
+++ b/Boots.Tests/BootstrapperTests.cs
@@ -30,12 +30,14 @@ namespace Boots.Tests
 			await boots.Install ();
 		}
 
-		[SkippableFact]
-		public async Task InstallMsi ()
+		[SkippableTheory]
+		[InlineData ("https://download-installer.cdn.mozilla.net/pub/firefox/releases/82.0/win64/en-US/Firefox%20Setup%2082.0.msi")]
+		[InlineData ("https://aka.ms/download-jdk/microsoft-jdk-11.0.12.7.1-windows-x64.msi")]
+		public async Task InstallMsi (string url)
 		{
 			Skip.If (!Helpers.IsWindows, ".msis are only supported on Windows");
 			boots.FileType = FileType.msi;
-			boots.Url = "https://download-installer.cdn.mozilla.net/pub/firefox/releases/82.0/win64/en-US/Firefox%20Setup%2082.0.msi";
+			boots.Url = url;
 			await boots.Install ();
 			// Two installs back-to-back should be fine
 			await boots.Install ();


### PR DESCRIPTION
.NET MAUI is hitting an issue installing this `.msi` on a machine
where it is already installed:

    Inferring .msi from URL.
    Downloading https://aka.ms/download-jdk/microsoft-jdk-11.0.12.7.1-windows-x64.msi
    Writing to C:\Users\XamarinForms\AppData\Local\Temp\mkrb5aj3.bqp.msi
    ...
    Error: One or more errors occurred. ('msiexec' with arguments '/i "C:\Users\XamarinForms\AppData\Local\Temp\mkrb5aj3.bqp.msi" /qn /L*V "C:\Users\XamarinForms\AppData\Local\Temp\tmpE86B.tmp"' exited with code 1603)
        'msiexec' with arguments '/i "C:\Users\XamarinForms\AppData\Local\Temp\mkrb5aj3.bqp.msi" /qn /L*V "C:\Users\XamarinForms\AppData\Local\Temp\tmpE86B.tmp"' exited with code 1603

Let's test this scenario, and see if this reproduces the issue.