### PR TITLE
[ci] fix bitrise by using JDK 1.8

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -11,6 +11,9 @@ workflows:
     - activate-ssh-key@4.0.5:
         run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
     - git-clone@4.0.25: {}
+    - set-java-version@1:
+        inputs:
+        - set_java_version: '8'
     - android-sdk-update@1:
         inputs:
         - sdk_version: '30'


### PR DESCRIPTION
Context: https://support.bitrise.io/hc/en-us/articles/360017059718-Using-Android-SDK-tools-with-Java-11
Context: https://www.bitrise.io/integrations/steps/set-java-version

We should use the `set-java-version` step to select JDK 1.8.