### PR TITLE
[build] drop netcoreapp2.1 support

### DIFF
--- a/Boots/Boots.csproj
+++ b/Boots/Boots.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RollForward>Major</RollForward>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>boots</ToolCommandName>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ jobs:
   - template: scripts/build-and-test.yaml
     parameters:
       platform: windows
+      xaversion: 11.4
 
   - powershell: dotnet cake
     displayName: Cake test
@@ -42,7 +43,7 @@ jobs:
   - template: scripts/build-and-test.yaml
     parameters:
       platform: mac
-      xaversion: 11.3
+      xaversion: 12.0
 
   - bash: dotnet cake --target=Mono && dotnet cake
     workingDirectory: Cake.Boots


### PR DESCRIPTION
The .NET 6 SDK doesn't support `netcoreapp2.1`, so dropping it.