### PR TITLE
[appveyor] only build 1 project

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,7 @@ version: '{build}'
 branches:
   only:
   - main
+  - /.+appveyor.+/
 image: macOS
 test: false
 environment:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ branches:
   only:
   - main
 image: macOS
-test: off
+test: false
 environment:
   Configuration: Release
   Verbosity: Diagnostic
@@ -11,7 +11,7 @@ build_script:
 - sh: >-
     export PATH="$PATH:~/.dotnet/tools" &&
     dotnet tool update --global Cake.Tool &&
-    dotnet build boots.sln &&
+    dotnet build Cake.Boots/Cake.Boots.csproj &&
     cd Cake.Boots &&
     dotnet cake --target=Mono --verbosity=$Verbosity &&
     dotnet cake --verbosity=$Verbosity


### PR DESCRIPTION
This avoids the missing .NET 6 install for the tests.

The macOS image has .NET 5 as the latest right now:

https://www.appveyor.com/docs/macos-images-software/