### PR TITLE
Add --downgrade-first option.

### DIFF
--- a/Boots.Core/Bootstrapper.cs
+++ b/Boots.Core/Bootstrapper.cs
@@ -27,6 +27,8 @@ namespace Boots.Core
 
 		public string Url { get; set; } = "";
 
+		public bool DowngradeFirst { get; set; }
+
 		public TextWriter Logger { get; set; } = Console.Out;
 
 		internal AsyncPolicy ActivePolicy { get; set; } = Policy.NoOpAsync ();

--- a/Boots.Tests/BootstrapperTests.cs
+++ b/Boots.Tests/BootstrapperTests.cs
@@ -32,6 +32,18 @@ namespace Boots.Tests
 		}
 
 		[SkippableFact]
+		public async Task DowngradeFirst ()
+		{
+			Skip.If (!Helpers.IsWindows, "DowngradeFirst is only applicable on Windows");
+			string vs = Environment.GetEnvironmentVariable("AGENT_JOBNAME") == "vs2019" ? "2019" : "2022";
+			boots.Url = $"https://github.com/codecadwallader/codemaid/releases/download/v12.0/CodeMaid.VS{vs}.v12.0.300.vsix";
+			await boots.Install ();
+			 // NOTE: this only does something for .vsix files on Windows
+			boots.DowngradeFirst = true;
+			await boots.Install ();
+		}
+
+		[SkippableFact]
 		public async Task InstallMsi ()
 		{
 			Skip.If (!Helpers.IsWindows, ".msis are only supported on Windows");

--- a/Boots.Tests/BootstrapperTests.cs
+++ b/Boots.Tests/BootstrapperTests.cs
@@ -15,12 +15,17 @@ namespace Boots.Tests
 			boots.Logger = new TestWriter (output);
 		}
 
+		string GetCodeMaidUrl()
+		{
+			string vs = Environment.GetEnvironmentVariable("AGENT_JOBNAME") == "vs2019" ? "2019" : "2022";
+			return $"https://github.com/codecadwallader/codemaid/releases/download/v12.0/CodeMaid.VS{vs}.v12.0.300.vsix";
+		}
+
 		[SkippableFact]
 		public async Task SimpleInstall ()
 		{
 			if (Helpers.IsWindows) {
-				string vs = Environment.GetEnvironmentVariable("AGENT_JOBNAME") == "vs2019" ? "2019" : "2022";
-				boots.Url = $"https://github.com/codecadwallader/codemaid/releases/download/v12.0/CodeMaid.VS{vs}.v12.0.300.vsix";
+				boots.Url = GetCodeMaidUrl();
 			} else if (Helpers.IsMac) {
 				boots.Url = "https://aka.ms/objective-sharpie";
 			} else {
@@ -35,8 +40,7 @@ namespace Boots.Tests
 		public async Task DowngradeFirst ()
 		{
 			Skip.If (!Helpers.IsWindows, "DowngradeFirst is only applicable on Windows");
-			string vs = Environment.GetEnvironmentVariable("AGENT_JOBNAME") == "vs2019" ? "2019" : "2022";
-			boots.Url = $"https://github.com/codecadwallader/codemaid/releases/download/v12.0/CodeMaid.VS{vs}.v12.0.300.vsix";
+			boots.Url = GetCodeMaidUrl();
 			await boots.Install ();
 			 // NOTE: this only does something for .vsix files on Windows
 			boots.DowngradeFirst = true;

--- a/Boots/Program.cs
+++ b/Boots/Program.cs
@@ -65,6 +65,8 @@ namespace Boots
 				{
 					Argument = new Argument<int>("int")
 				},
+				new Option ("--downgrade-first",
+					$"Downgrades the existing vsix back to the shipped VS default before install. This allows an earlier vsix to be installed."),
 			};
 			rootCommand.Name = "boots";
 			rootCommand.AddValidator (Validator);
@@ -102,7 +104,8 @@ namespace Boots
 			FileType? fileType = null,
 			double? timeout = null,
 			double? readWriteTimeout = null,
-			int? retries = null)
+			int? retries = null,
+			bool downgradeFirst = false)
 		{
 			var cts = new CancellationTokenSource ();
 			Console.CancelKeyPress += (sender, e) => cts.Cancel ();
@@ -120,6 +123,7 @@ namespace Boots
 			if (retries != null) {
 				boots.NetworkRetries = retries.Value;
 			}
+			boots.DowngradeFirst = downgradeFirst;
 			SetChannelAndProduct (boots, alpha, ReleaseChannel.Alpha);
 			SetChannelAndProduct (boots, preview, ReleaseChannel.Preview);
 			SetChannelAndProduct (boots, stable,  ReleaseChannel.Stable);


### PR DESCRIPTION
Because we are sharing build agents with a process that is testing PR `.vsix` files, we often need to replace those PR builds with a stable lower version `.vsix`, which is not supported by `vsixinstaller.exe`.  Add the option `--downgrade-first`, which will first revert the installed package back to the version that ships with the VS version, so we may then upgrade it to our desired version.

Log file where downgrade was performed but not needed (error is written to log, but does not stop the process):
[no-downgrade-needed.txt](https://github.com/jonathanpeppers/boots/files/8327694/no-downgrade-needed.txt)

Log file where downgrade was needed (first installs higher version, then downgrades and installs desired version):
[downgrade-needed.txt](https://github.com/jonathanpeppers/boots/files/8327695/downgrade-needed.txt)
 