### PR TITLE
[build] remove VS 2019 job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 
 jobs:
 
-- job: vs2022
+- job: windows
   pool:
     vmImage: windows-2022
     demands: msbuild
@@ -24,21 +24,7 @@ jobs:
 
   - template: scripts/build-and-test.yaml
     parameters:
-      name: vs2022
-
-  - powershell: dotnet cake
-    displayName: Cake test
-    workingDirectory: Cake.Boots
-
-- job: vs2019
-  pool:
-    vmImage: windows-2019
-    demands: msbuild
-  steps:
-
-  - template: scripts/build-and-test.yaml
-    parameters:
-      name: vs2019
+      name: windows
 
   - powershell: dotnet cake
     displayName: Cake test


### PR DESCRIPTION
We can't install the latest Xamarin.Android builds anymore in 2019, so I think we can just remove this lane now.

I don't think it's going to catch any bugs in `boots` to keep it anyway.